### PR TITLE
[DOC] Escodoo + Engenere contributors

### DIFF
--- a/l10n_br_sale/readme/CONTRIBUTORS.rst
+++ b/l10n_br_sale/readme/CONTRIBUTORS.rst
@@ -1,4 +1,18 @@
-* Renato Lima <renato.lima@akretion.com.br>
-* Raphaël Valyi <raphael.valyi@akretion.com.br>
-* Luis Felipe Mileo <mileo@kmee.com.br>
-* Michell Stuttgart <michell.stuttgart@kmee.com.br>
+* `AKRETION <https://akretion.com/pt-BR/>`_:
+
+  * Raphaël Valyi <raphael.valyi@akretion.com.br>
+  * Renato Lima <renato.lima@akretion.com.br>
+  * Magno Costa <magno.costa@akretion.com.br>
+
+* `KMEE <https://kmee.com.br>`_:
+
+  * Luis Felipe Mileo <mileo@kmee.com.br>
+  * Michell Stuttgart <michell.stuttgart@kmee.com.br>
+
+* `ESCODOO <https://escodoo.com.br>`_:
+
+  * Marcel Savegnago <marcel.savegnago@escodoo.com.br>
+
+* `ENGENERE <https://engenere.one>`_:
+
+  * Felipe Motter Pereira <felipe@engenere.one>

--- a/l10n_br_sale/tests/test_l10n_br_sale_discount.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_discount.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2022-Today - Engenere (<https://engenere.one>).
+# @author Felipe Motter Pereira <felipe@engenere.one>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 from odoo.tests import Form, SavepointCase
 
 


### PR DESCRIPTION
1. formata o arquivo de contribuidores corretamente
2. acrescenta o Magno por conta do trabalho pesado em https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_sale/models/sale_order_line.py desde a v12
3. acrescenta o Marcel pelo trabalho de migração para a v14 que não tinha sido nada trivial: https://github.com/OCA/l10n-brazil/pull/1854
4. acrescenta o Felipe pela limpeza no discount e os testes.
5. acrescenta os copyrights da Engenere no novo arquivo de tests

cc @felipemotter @antoniospneto @renatonlima @marcelsavegnago @mbcosta