### PR TITLE
[IMP][l10n_br_nfe][l10n_br_account_nfe]: Adicionando Lib BrazilFiscalReport para geração de Danfe

### DIFF
--- a/l10n_br_account_nfe/__init__.py
+++ b/l10n_br_account_nfe/__init__.py
@@ -1,3 +1,4 @@
 from .hooks import post_init_hook
 
 from . import models
+from . import report

--- a/l10n_br_account_nfe/__manifest__.py
+++ b/l10n_br_account_nfe/__manifest__.py
@@ -22,6 +22,7 @@
     ],
     "data": [
         "views/account_payment_mode.xml",
+        "report/danfe_report.xml",
     ],
     "post_init_hook": "post_init_hook",
     "installable": True,

--- a/l10n_br_account_nfe/report/__init__.py
+++ b/l10n_br_account_nfe/report/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/l10n_br_account_nfe/report/danfe_report.xml
+++ b/l10n_br_account_nfe/report/danfe_report.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="report_danfe_account" model="ir.actions.report">
+        <field name="name">DANFE</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">main_template_danfe_account</field>
+        <field name="report_file">main_template_danfe_account</field>
+        <field name="print_report_name">'%s' % (object.document_key)</field>
+        <field name="binding_model_id" ref="account.model_account_move" />
+        <field name="binding_type">report</field>
+    </record>
+</odoo>

--- a/l10n_br_account_nfe/report/ir_actions_report.py
+++ b/l10n_br_account_nfe/report/ir_actions_report.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def temp_xml_autorizacao(self, xml_string):
+        return super().temp_xml_autorizacao(xml_string=xml_string)
+
+    def _render_qweb_html(self, res_ids, data=None):
+        if self.report_name == "main_template_danfe_account":
+            return
+        return super()._render_qweb_html(res_ids, data=data)
+
+    def _render_qweb_pdf(self, res_ids, data=None):
+        if self.report_name not in ["main_template_danfe_account"]:
+            return super()._render_qweb_pdf(res_ids, data=data)
+
+        nfe = self.env["account.move"].search([("id", "in", res_ids)])
+
+        return self._render_danfe(nfe)
+
+    def _render_danfe(self, nfe):
+        return super()._render_danfe(nfe=nfe)

--- a/l10n_br_account_nfe/tests/__init__.py
+++ b/l10n_br_account_nfe/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_nfe_generate_tags_cobr_dup_pag
 from . import test_nfce_contingency
+from . import test_nfe_danfe_account

--- a/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
+++ b/l10n_br_account_nfe/tests/test_nfe_danfe_account.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
+from odoo.tests import SavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestGeneratePaymentInfo(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_generate_danfe_brazil_fiscal_report(self):
+        nfe = self.env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
+        nfe.action_post()
+
+        danfe_report = self.env["ir.actions.report"].search(
+            [("report_name", "=", "main_template_danfe_account")]
+        )
+        danfe_pdf = danfe_report._render_qweb_pdf([nfe.id])
+        self.assertTrue(danfe_pdf)
+
+    def test_generate_danfe_erpbrasil_edoc(self):
+        nfe = self.env.ref("l10n_br_account_nfe.demo_nfe_dados_de_cobranca")
+        nfe.company_id.danfe_library = "erpbrasil.edoc.pdf"
+
+        with patch("erpbrasil.edoc.pdf.base.ImprimirXml.imprimir") as mock_make_pdf:
+            mock_make_pdf.return_value = b"Mock PDF"
+
+            nfe.action_post()
+
+            danfe_report = self.env["ir.actions.report"].search(
+                [("report_name", "=", "main_template_danfe_account")]
+            )
+            danfe_pdf = danfe_report._render_qweb_pdf([nfe.id])
+            self.assertTrue(danfe_pdf)

--- a/l10n_br_nfe/__init__.py
+++ b/l10n_br_nfe/__init__.py
@@ -4,3 +4,4 @@ from .hooks import post_init_hook
 from . import models
 from . import tests
 from . import wizards
+from . import report

--- a/l10n_br_nfe/__manifest__.py
+++ b/l10n_br_nfe/__manifest__.py
@@ -35,6 +35,7 @@
         # Report
         "report/reports.xml",
         "report/danfe_nfce.xml",
+        "report/danfe_report.xml",
         # Wizards
         "wizards/import_document.xml",
         # Actions,
@@ -58,6 +59,7 @@
             "erpbrasil.edoc>=2.5.2",
             "erpbrasil.edoc.pdf",
             "erpbrasil.base>=2.3.0",
+            "BrazilFiscalReport",
         ],
     },
 }

--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -6,6 +6,13 @@ NFE_VERSIONS = [("1.10", "1.10"), ("2.00", "2.00"), ("3.10", "3.10"), ("4.00", "
 
 NFE_VERSION_DEFAULT = "4.00"
 
+DANFE_LIBRARY = [
+    ("brazil_fiscal_report", "Brazil Fiscal Report"),
+    ("erpbrasil.edoc.pdf", "ERPBrasil"),
+]
+
+DANFE_LIBRARY_DEFAULT = "brazil_fiscal_report"
+
 
 NFE_ENVIRONMENTS = [("1", "Produção"), ("2", "Homologação")]
 

--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -11,9 +11,7 @@ from datetime import datetime
 from erpbrasil.assinatura import certificado as cert
 from erpbrasil.base.fiscal import cnpj_cpf
 from erpbrasil.base.fiscal.edoc import ChaveEdoc
-from erpbrasil.edoc.pdf import base
 from erpbrasil.transmissao import TransmissaoSOAP
-from lxml import etree
 from nfelib.nfe.bindings.v4_0.nfe_v4_00 import Nfe
 from nfelib.nfe.ws.edoc_legacy import NFCeAdapter as edoc_nfce, NFeAdapter as edoc_nfe
 from requests import Session
@@ -1092,35 +1090,21 @@ class NFe(spec_models.StackedModel):
         if not self.filtered(filter_processador_edoc_nfe):
             return super().make_pdf()
 
+        attachment_data = {
+            "name": self.document_key + ".pdf",
+            "res_model": self._name,
+            "res_id": self.id,
+            "mimetype": "application/pdf",
+            "type": "binary",
+        }
+        report = self.env.ref("l10n_br_nfe.report_danfe")
+        pdf_data = report._render_qweb_pdf(self.fiscal_line_ids.document_id.ids)
+        attachment_data["datas"] = base64.b64encode(pdf_data[0])
         file_pdf = self.file_report_id
         self.file_report_id = False
         file_pdf.unlink()
 
-        if self.authorization_file_id:
-            arquivo = self.authorization_file_id
-            xml_string = base64.b64decode(arquivo.datas).decode()
-        else:
-            arquivo = self.send_file_id
-            xml_string = base64.b64decode(arquivo.datas).decode()
-            xml_string = self.temp_xml_autorizacao(xml_string)
-
-        pdf = base.ImprimirXml.imprimir(
-            string_xml=xml_string,
-            # output_dir=self.authorization_event_id.file_path
-        )
-        # TODO: Alterar a opção output_dir para devolter também o arquivo do XML
-        # no retorno, evitando a releitura do arquivo.
-
-        self.file_report_id = self.env["ir.attachment"].create(
-            {
-                "name": self.document_key + ".pdf",
-                "res_model": self._name,
-                "res_id": self.id,
-                "datas": base64.b64encode(pdf),
-                "mimetype": "application/pdf",
-                "type": "binary",
-            }
-        )
+        self.file_report_id = self.env["ir.attachment"].create(attachment_data)
 
     def import_nfe_xml(self, xml, edoc_type="out"):
         document = (
@@ -1136,26 +1120,6 @@ class NFe(spec_models.StackedModel):
             document.issuer = "partner"
 
         return document
-
-    def temp_xml_autorizacao(self, xml_string):
-        """TODO: Migrate-me to erpbrasil.edoc.pdf ASAP"""
-        root = etree.fromstring(xml_string)
-        ns = {None: "http://www.portalfiscal.inf.br/nfe"}
-        new_root = etree.Element("nfeProc", nsmap=ns)
-
-        protNFe_node = etree.Element("protNFe")
-        infProt = etree.SubElement(protNFe_node, "infProt")
-        etree.SubElement(infProt, "tpAmb").text = "2"
-        etree.SubElement(infProt, "verAplic").text = ""
-        etree.SubElement(infProt, "dhRecbto").text = None
-        etree.SubElement(infProt, "nProt").text = ""
-        etree.SubElement(infProt, "digVal").text = ""
-        etree.SubElement(infProt, "cStat").text = ""
-        etree.SubElement(infProt, "xMotivo").text = ""
-
-        new_root.append(root)
-        new_root.append(protNFe_node)
-        return etree.tostring(new_root)
 
     def _document_cancel(self, justificative):
         result = super()._document_cancel(justificative)

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -7,6 +7,8 @@ from odoo import api, fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 from ..constants.nfe import (
+    DANFE_LIBRARY,
+    DANFE_LIBRARY_DEFAULT,
     NFCE_DANFE_LAYOUT_DEFAULT,
     NFCE_DANFE_LAYOUTS,
     NFE_DANFE_LAYOUT_DEFAULT,
@@ -129,6 +131,16 @@ class ResCompany(spec_models.SpecModel):
         string="CSC Code",
         help="Código CSC (Código de Segurança do Contribuinte) "
         "fornecido pela SEFAZ para a NFC-e",
+    )
+    danfe_library = fields.Selection(
+        selection=DANFE_LIBRARY,
+        default=DANFE_LIBRARY_DEFAULT,
+        help="""
+        Choose the library used for generating the DANFE
+        (Document Auxiliary for Nota Fiscal Eletrônica).
+        Options include 'erpbrasil.edoc.pdf' and 'brazil_fiscal_report'.
+        The default library is set to 'erpbrasil.edoc.pdf'.
+        """,
     )
 
     def _compute_nfe_data(self):

--- a/l10n_br_nfe/report/__init__.py
+++ b/l10n_br_nfe/report/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/l10n_br_nfe/report/danfe_report.xml
+++ b/l10n_br_nfe/report/danfe_report.xml
@@ -1,0 +1,12 @@
+<odoo>
+        <record id="report_danfe" model="ir.actions.report">
+            <field name="name">DANFE</field>
+            <field name="model">l10n_br_fiscal.document</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">main_template_danfe</field>
+            <field name="report_file">main_template_danfe</field>
+            <field name="print_report_name">'%s' % (object.document_key)</field>
+            <field name="binding_model_id" ref="model_l10n_br_fiscal_document" />
+            <field name="binding_type">report</field>
+        </record>
+</odoo>

--- a/l10n_br_nfe/report/ir_actions_report.py
+++ b/l10n_br_nfe/report/ir_actions_report.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import base64
+import logging
+from io import BytesIO
+
+from brazilfiscalreport.pdf_docs import Danfe
+from erpbrasil.edoc.pdf import base
+from lxml import etree
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def temp_xml_autorizacao(self, xml_string):
+        """TODO: Migrate-me to erpbrasil.edoc.pdf ASAP"""
+        root = etree.fromstring(xml_string)
+        ns = {None: "http://www.portalfiscal.inf.br/nfe"}
+        new_root = etree.Element("nfeProc", nsmap=ns)
+
+        protNFe_node = etree.Element("protNFe")
+        infProt = etree.SubElement(protNFe_node, "infProt")
+        etree.SubElement(infProt, "tpAmb").text = "2"
+        etree.SubElement(infProt, "verAplic").text = ""
+        etree.SubElement(infProt, "dhRecbto").text = None
+        etree.SubElement(infProt, "nProt").text = ""
+        etree.SubElement(infProt, "digVal").text = ""
+        etree.SubElement(infProt, "cStat").text = ""
+        etree.SubElement(infProt, "xMotivo").text = ""
+
+        new_root.append(root)
+        new_root.append(protNFe_node)
+        return etree.tostring(new_root)
+
+    def _render_qweb_html(self, res_ids, data=None):
+        if self.report_name == "main_template_danfe":
+            return
+
+        return super()._render_qweb_html(res_ids, data=data)
+
+    def _render_qweb_pdf(self, res_ids, data=None):
+        if self.report_name not in ["main_template_danfe"]:
+            return super()._render_qweb_pdf(res_ids, data=data)
+
+        nfe = self.env["l10n_br_fiscal.document"].search([("id", "in", res_ids)])
+
+        return self._render_danfe(nfe)
+
+    def _render_danfe(self, nfe):
+        if nfe.document_type != "55":
+            raise UserError(_("You can only print a danfe of a NFe(55)."))
+
+        nfe_xml = False
+        if nfe.authorization_file_id:
+            nfe_xml = base64.b64decode(nfe.authorization_file_id.datas)
+        elif nfe.send_file_id:
+            nfe_xml = base64.b64decode(nfe.send_file_id.datas)
+
+        if not nfe_xml:
+            raise UserError(_("No xml file was found."))
+
+        if nfe.company_id.danfe_library == "erpbrasil.edoc.pdf":
+            nfe_xml = self.temp_xml_autorizacao(nfe_xml)
+            return self.render_danfe_erpbrasil(nfe_xml)
+        elif nfe.company_id.danfe_library == "brazil_fiscal_report":
+            return self.render_danfe_brazilfiscalreport(nfe, nfe_xml)
+
+    def render_danfe_brazilfiscalreport(self, nfe, nfe_xml):
+        logo = False
+        if nfe.issuer == "company" and nfe.company_id.logo:
+            logo = base64.b64decode(nfe.company_id.logo)
+        elif nfe.issuer != "company" and nfe.company_id.logo_web:
+            logo = base64.b64decode(nfe.company_id.logo_web)
+
+        if logo:
+            tmpLogo = BytesIO()
+            tmpLogo.write(logo)
+            tmpLogo.seek(0)
+        else:
+            tmpLogo = False
+
+        xml_element = nfe_xml
+        oDanfe = Danfe(xmls=xml_element, image=tmpLogo)
+
+        tmpDanfe = BytesIO()
+        oDanfe.output(tmpDanfe)
+        danfe_file = tmpDanfe.getvalue()
+        tmpDanfe.close()
+
+        return danfe_file, "pdf"
+
+    def render_danfe_erpbrasil(self, nfe_xml):
+        pdf = base.ImprimirXml.imprimir(
+            string_xml=nfe_xml,
+            # output_dir=self.authorization_event_id.file_path
+            # TODO: Alterar a opção output_dir para devolter também o arquivo do XML
+            # no retorno, evitando a releitura do arquivo.
+        )
+
+        return pdf, "pdf"

--- a/l10n_br_nfe/tests/__init__.py
+++ b/l10n_br_nfe/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_nfe_xml_validation
 from . import test_res_partner
 from . import test_nfe_dfe
 from . import test_nfe_mde
+from . import test_nfe_danfe

--- a/l10n_br_nfe/tests/test_nfe_danfe.py
+++ b/l10n_br_nfe/tests/test_nfe_danfe.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestDanfeGeneration(TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_generate_danfe_brazil_fiscal_report(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.action_document_confirm()
+        nfe.view_pdf()
+
+        self.assertTrue(nfe.file_report_id)
+
+    def test_generate_danfe_erpbrasil_edoc(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.company_id.danfe_library = "erpbrasil.edoc.pdf"
+
+        with patch("erpbrasil.edoc.pdf.base.ImprimirXml.imprimir") as mock_make_pdf:
+            mock_make_pdf.return_value = b"Mock PDF"
+
+            nfe.action_document_confirm()
+            nfe.make_pdf()
+
+            self.assertTrue(nfe.file_report_id)
+
+    def test_generate_danfe_document_type_error(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.document_type = "1"
+
+        with self.assertRaises(UserError) as context_document_type:
+            nfe.action_document_confirm()
+            nfe.view_pdf()
+        self.assertTrue(
+            context_document_type.exception.args[0]
+            == "You can only print a danfe of a NFe(55)."
+        )
+
+    def test_generate_danfe_brazil_fiscal_report_partner(self):
+        nfe = self.env.ref("l10n_br_nfe.demo_nfe_natural_icms_18_red_51_11")
+        nfe.action_document_confirm()
+        nfe.issuer = "partner"
+        nfe.view_pdf()
+
+        self.assertTrue(nfe.file_report_id)

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -21,6 +21,7 @@
                             />
                           <field name="nfe_authorize_accountant_download_xml" />
                           <field name="nfe_authorize_technical_download_xml" />
+                          <field name="danfe_library" />
                       </group>
                   </group>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # generated from manifests external_dependencies
 brazilcep
+BrazilFiscalReport
 email-validator
 erpbrasil.assinatura>=1.7.0
 erpbrasil.base>=2.3.0


### PR DESCRIPTION

Adicionando a lib no modulo l10n_br_nfe para geração de Danfe a empresa escolhera qual lib usar através da configurações da empresa:

![fgsddgsdgvbxcb](https://github.com/Engenere/l10n-brazil/assets/142639425/335d9c57-3265-4d5d-b3d7-95f22c0d754a)


Clicando no botão visualizar PDF ira fazer a geração do Danfe:

![fdsgdds](https://github.com/Engenere/l10n-brazil/assets/142639425/462ff074-f1d7-4757-ae7e-84255f988718)



