### PR TITLE
[IMP] l10n_br_nfe: Invoice Dashboard to BrazilFiscalReport lib

### DIFF
--- a/l10n_br_nfe/constants/nfe.py
+++ b/l10n_br_nfe/constants/nfe.py
@@ -13,6 +13,12 @@ DANFE_LIBRARY = [
 
 DANFE_LIBRARY_DEFAULT = "brazil_fiscal_report"
 
+DANFE_INVOICE_DISPLAY = [
+    ("full_details", "Full Details"),
+    ("duplicates_only", "Duplicates Only"),
+]
+
+DANFE_INVOICE_DISPLAY_DEFAULT = "full_details"
 
 NFE_ENVIRONMENTS = [("1", "Produção"), ("2", "Homologação")]
 

--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -7,6 +7,8 @@ from odoo import api, fields
 from odoo.addons.spec_driven_model.models import spec_models
 
 from ..constants.nfe import (
+    DANFE_INVOICE_DISPLAY,
+    DANFE_INVOICE_DISPLAY_DEFAULT,
     DANFE_LIBRARY,
     DANFE_LIBRARY_DEFAULT,
     NFCE_DANFE_LAYOUT_DEFAULT,
@@ -141,6 +143,17 @@ class ResCompany(spec_models.SpecModel):
         Options include 'erpbrasil.edoc.pdf' and 'brazil_fiscal_report'.
         The default library is set to 'erpbrasil.edoc.pdf'.
         """,
+    )
+
+    danfe_invoice_display = fields.Selection(
+        selection=DANFE_INVOICE_DISPLAY,
+        default=DANFE_INVOICE_DISPLAY_DEFAULT,
+        help="Choose to generate a full or incomplete invoice frame in the DANFE.",
+    )
+
+    danfe_display_pis_cofins = fields.Boolean(
+        default=False,
+        help="Select whether PIS and COFINS should be displayed in DANFE.",
     )
 
     def _compute_nfe_data(self):

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -21,7 +21,6 @@
                             />
                           <field name="nfe_authorize_accountant_download_xml" />
                           <field name="nfe_authorize_technical_download_xml" />
-                          <field name="danfe_library" />
                       </group>
                   </group>
 
@@ -30,6 +29,22 @@
                         <field name="nfce_qrcode_version" />
                         <field name="nfce_csc_token" />
                         <field name="nfce_csc_code" />
+                    </group>
+                  </group>
+
+                  <group name="danfe_settings" string="DANFE Settings">
+                    <group>
+                        <field name="danfe_library" />
+                        <field
+                                name="danfe_invoice_display"
+                                string="Invoice Display"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
+                        <field
+                                name="danfe_display_pis_cofins"
+                                string="PIS/COFINS Display"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
                     </group>
                   </group>
               </page>


### PR DESCRIPTION
Objetivo da PR

Adicionando a possibilidade de gerar  DANFE com quadro de faturas completo ou incompleto.
Adicionando configuração de gerar DANFE com os campos PIS e COFINS.

Criado Grupo novo para configurações de DANFE e campo selection para adicionar a opção de quadro de faturas completo ou incompleto e também campo Booleano para os campos PIS E COFINS.
![222](https://github.com/Engenere/l10n-brazil/assets/142639425/f131e468-4661-4cf7-a976-ff3a699109f7)


Fatura com quadro de faturas completa:
![teste_01_completa](https://github.com/Engenere/l10n-brazil/assets/142639425/bd90d5b0-5821-4882-ab9b-2785d50b7bae)

Fatura com quadro de faturas incompleta:
![teste_02_incompleta](https://github.com/Engenere/l10n-brazil/assets/142639425/69d64946-875b-40e9-975c-5e94f5123209)

Exemplo da Geração da DANFE com os campos PIS E COFINS:
[DANFE-PIS E COFINS](https://github.com/Engenere/BrazilFiscalReport/blob/main/tests/generated/danfe/danfe_pis_confins.pdf)



