### PR TITLE
[14.0][IMP] l10n_br_nfe: Danfe margins configuration

### DIFF
--- a/l10n_br_nfe/models/res_company.py
+++ b/l10n_br_nfe/models/res_company.py
@@ -187,6 +187,22 @@ class ResCompany(spec_models.SpecModel):
         help="Select whether PIS and COFINS should be displayed in DANFE.",
     )
 
+    danfe_margin_top = fields.Integer(
+        default=2, help="Top margin in mm for the DANFE layout."
+    )
+
+    danfe_margin_right = fields.Integer(
+        default=2, help="Right margin in mm for the DANFE layout."
+    )
+
+    danfe_margin_bottom = fields.Integer(
+        default=2, help="Bottom margin in mm for the DANFE layout."
+    )
+
+    danfe_margin_left = fields.Integer(
+        default=2, help="Left margin in mm for the DANFE layout."
+    )
+
     def _compute_nfe_data(self):
         # compute because a simple related field makes the match_record fail
         for rec in self:

--- a/l10n_br_nfe/report/ir_actions_report.py
+++ b/l10n_br_nfe/report/ir_actions_report.py
@@ -83,9 +83,7 @@ class IrActionsReport(models.Model):
             tmpLogo.seek(0)
         else:
             tmpLogo = False
-
-        danfe_invoice_display = nfe.company_id.danfe_invoice_display
-        config = self._get_danfe_config(tmpLogo, danfe_invoice_display)
+        config = self._get_danfe_config(tmpLogo)
         if nfe.company_id.danfe_display_pis_cofins:
             config.display_pis_cofins = True
 
@@ -98,13 +96,18 @@ class IrActionsReport(models.Model):
 
         return danfe_file, "pdf"
 
-    def _get_danfe_config(self, tmpLogo, danfe_invoice_display):
+    def _get_danfe_config(self, tmpLogo):
         danfe_config = {
             "logo": tmpLogo,
-            "margins": Margins(top=2, right=2, bottom=2, left=2),
+            "margins": Margins(
+                top=self.env.company.danfe_margin_top,
+                right=self.env.company.danfe_margin_right,
+                bottom=self.env.company.danfe_margin_bottom,
+                left=self.env.company.danfe_margin_left,
+            ),
         }
 
-        if danfe_invoice_display == "duplicates_only":
+        if self.env.company.danfe_invoice_display == "duplicates_only":
             danfe_config["invoice_display"] = InvoiceDisplay.DUPLICATES_ONLY
 
         return DanfeConfig(**danfe_config)

--- a/l10n_br_nfe/views/res_company_view.xml
+++ b/l10n_br_nfe/views/res_company_view.xml
@@ -57,6 +57,26 @@
                                 string="PIS/COFINS Display"
                                 attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
                             />
+                            <field
+                                name="danfe_margin_top"
+                                string="Margin Top"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
+                        <field
+                                name="danfe_margin_right"
+                                string="Margin Right"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
+                            <field
+                                name="danfe_margin_bottom"
+                                string="Margin Bottom"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
+                        <field
+                                name="danfe_margin_left"
+                                string="Margin Left"
+                                attrs="{'invisible': [('danfe_library', '!=', 'brazil_fiscal_report')]}"
+                            />
                     </group>
                   </group>
               </page>


### PR DESCRIPTION
## Objetivo da PR

- Usuario ter a opção de escolher a margens da DANFE na lib BrazilFiscalReport.

![margins2](https://github.com/user-attachments/assets/3e0cd0d8-84de-483f-bfe9-4bdad044aa39)

