### PR TITLE
[16.0][FIX] l10n_br_fiscal: propagate ind_final to lines on partner change

### DIFF
--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -411,6 +411,21 @@ class Document(models.Model):
     def _get_fiscal_lines_field_name(self):
         return "fiscal_line_ids"
 
+    def write(self, vals):
+        old_ind_final = {doc.id: doc.ind_final for doc in self}
+        result = super().write(vals)
+        # ind_final may change directly (manual edit) or indirectly
+        # (partner_id change triggers _compute_ind_final). Flush to
+        # ensure the post-compute value is available, then propagate
+        # to lines when it actually changed.
+        self.flush_recordset(["ind_final"])
+        for doc in self:
+            if doc.ind_final != old_ind_final.get(doc.id):
+                for line in doc.fiscal_line_ids:
+                    if line.ind_final != doc.ind_final:
+                        line.ind_final = doc.ind_final
+        return result
+
     def unlink(self):
         forbidden_states_unlink = [
             SITUACAO_EDOC_AUTORIZADA,

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -285,6 +285,68 @@ class TestDocumentEdition(TransactionCase):
             doc_after_total_update.fiscal_amount_total, 2776.48, places=2
         )
 
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved document must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the document
+        doc.write({"ind_final": "0"})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved document must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        doc.write({"partner_id": partner_not_final.id})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
     def test_difal_calculation(self):
         partner = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
         partner.ind_ie_dest = "9"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@
 odoo-test-helper  # Needed by spec_driven_model
 pyopenssl==22.1.0
 xmldiff
+# TEMP: fix for partner_bank_id cleared on refund (OCA/bank-payment#1555)
+odoo-addon-account_payment_partner @ git+https://github.com/Engenere/bank-payment@16.0-fix-compute-partner-bank-no-payment-mode#subdirectory=setup/account_payment_partner


### PR DESCRIPTION
## Resumo

Corrige a propagação do campo `ind_final` do documento fiscal para as linhas fiscais. Quando o `ind_final` muda no documento (manualmente ou via troca de parceiro), as linhas fiscais não atualizam.

## Como reproduzir

1. Criar uma fatura com `ind_final = "1"` (Consumidor final)
2. Salvar
3. Alterar `ind_final` para `"0"` (Não consumidor final)
4. Salvar

- **Antes do fix:** as linhas fiscais mantêm `ind_final = "1"` mesmo com o documento tendo `"0"`
- **Após o fix:** as linhas fiscais atualizam para `"0"` junto com o documento

O mesmo ocorre indiretamente: ao trocar o parceiro, o compute `_compute_ind_final` atualiza o `ind_final` do documento, mas as linhas não acompanham.

## Causa raiz

O campo `ind_final` em `l10n_br_fiscal.document.line` é `store=True, compute="_compute_ind_final"`, mas o método `_compute_ind_final` **não tem `@api.depends`**. O Odoo só executa o compute na criação do registro. Alterações posteriores no `ind_final` do documento não propagam para as linhas.

Adicionar `@api.depends("document_id.ind_final")` no compute da linha foi considerado, mas causa efeito cascata: durante `create()`, a atribuição de `document_id` dispara o compute chain via `_compute_fiscal_tax_ids` (que depende de `ind_final`), sobrescrevendo valores fiscais definidos manualmente pelo usuário.

## Solução

Override de `write()` no modelo `l10n_br_fiscal.document` que compara o `ind_final` antes e depois de qualquer write. Quando o valor muda (seja por edição manual ou por recompute via troca de parceiro), propaga para as linhas fiscais existentes. Essa abordagem:

- Só executa em writes explícitos (não em creates)
- Só propaga quando `ind_final` realmente muda
- Dispara corretamente a recomputação de impostos nas linhas afetadas