### PR TITLE
[FIX] l10n_br_fiscal: propaga ind_final para linhas via api.depends

### DIFF
--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -95,6 +95,10 @@ class DocumentLine(models.Model):
         related="document_id.edoc_purpose",
     )
 
+    @api.depends("document_id.ind_final")
+    def _compute_ind_final(self):
+        return super()._compute_ind_final()
+
     additional_data = fields.Text()
 
     @api.depends("product_id")

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -285,6 +285,68 @@ class TestDocumentEdition(TransactionCase):
             doc_after_total_update.fiscal_amount_total, 2776.48, places=2
         )
 
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved document must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the document
+        doc.write({"ind_final": "0"})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved document must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        doc.write({"partner_id": partner_not_final.id})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
     def test_difal_calculation(self):
         partner = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
         partner.ind_ie_dest = "9"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@
 odoo-test-helper  # Needed by spec_driven_model
 pyopenssl==22.1.0
 xmldiff
+# TEMP: fix for partner_bank_id cleared on refund (OCA/bank-payment#1555)
+odoo-addon-account_payment_partner @ git+https://github.com/Engenere/bank-payment@16.0-fix-compute-partner-bank-no-payment-mode#subdirectory=setup/account_payment_partner


### PR DESCRIPTION
## Resumo

- Adiciona `@api.depends("document_id.ind_final")` no `_compute_ind_final` da classe concreta `DocumentLine`.
- No mixin não é possível declarar o depends porque o campo do documento pai varia conforme o modelo que herda. Com o depends na classe concreta, o Odoo recalcula automaticamente o `ind_final` das linhas quando o valor muda no documento (ex: troca de parceiro).
- Inclui testes que validam a propagação do `ind_final` para as linhas ao alterar manualmente e ao trocar o parceiro.

## Plano de teste

- [ ] `test_ind_final_propagation_on_manual_change` — alterar `ind_final` diretamente no documento deve propagar para as linhas
- [ ] `test_ind_final_propagation_on_partner_change` — trocar o parceiro para um com `ind_final` diferente deve propagar para as linhas
- [ ] Testes existentes do `test_document_edition` continuam passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)