### PR TITLE
[16.0][FIX] l10n_br_fiscal: remove circular dependency on icms_cst_id

### DIFF
--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -420,7 +420,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
         "cfop_id",
         "icmssn_range_id",
         "icms_origin",
-        "icms_cst_id",
         "ind_final",
         "icms_relief_id",
     )
@@ -474,7 +473,6 @@ class FiscalDocumentLineMixin(models.AbstractModel):
                     cfop=line.cfop_id,
                     icmssn_range=line.icmssn_range_id,
                     icms_origin=line.icms_origin,
-                    icms_cst_id=line.icms_cst_id,
                     ind_final=line.ind_final,
                     icms_relief_id=line.icms_relief_id,
                 )

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -407,8 +407,6 @@ class Tax(models.Model):
         cfop = kwargs.get("cfop")
         fiscal_operation_type = operation_line.fiscal_operation_type or FISCAL_OUT
         ind_final = kwargs.get("ind_final", FINAL_CUSTOMER_NO)
-        cst = kwargs.get("icms_cst_id", self.env["l10n_br_fiscal.cst"])
-
         # Get Computed IPI Tax
         tax_dict_ipi = taxes_dict.get("ipi", {})
 
@@ -532,14 +530,15 @@ class Tax(models.Model):
                 }
             )
 
-        if kwargs.get("icms_relief_id") and cst["code"] in ICMS_CST_RELIEF:
+        cst = tax_dict.get("cst_id") or self.env["l10n_br_fiscal.cst"]
+        if kwargs.get("icms_relief_id") and cst.code in ICMS_CST_RELIEF:
             icms_base = kwargs.get("price_unit", 0.00) * kwargs.get("quantity", 0.00)
             icms_percent = tax_dict.get("percent_amount", 0.00) / 100
             icms_reduction = tax_dict.get("percent_reduction", 0.00) / 100
-            if cst["code"] in ["30", "40"]:
+            if cst.code in ["30", "40"]:
                 icms_relief = icms_base * icms_percent
                 tax_dict.update({"icms_relief": icms_relief})
-            elif cst["code"] in ["20", "70"]:
+            elif cst.code in ["20", "70"]:
                 icms_relief = (
                     icms_base
                     * (1 - (icms_percent * (1 - icms_reduction)))
@@ -561,7 +560,11 @@ class Tax(models.Model):
         tax_dict = taxes_dict.get(tax.tax_domain)
         partner = kwargs.get("partner")
         company = kwargs.get("company")
-        icms_cst_id = kwargs.get("icms_cst_id")
+        icms_cst = (
+            taxes_dict.get("icms", {}).get("cst_id")
+            or taxes_dict.get("icmssn", {}).get("cst_id")
+            or self.env["l10n_br_fiscal.cst"]
+        )
 
         if taxes_dict.get("icms"):
             if company.state_id != partner.state_id:
@@ -580,7 +583,7 @@ class Tax(models.Model):
         tax_dict["fcpst_base"] = taxes_dict.get("icmsst", {}).get("base", 0.00)
 
         # TODO Improve this condition
-        if icms_cst_id.code in ICSM_CST_CSOSN_ST_BASE:
+        if icms_cst.code in ICSM_CST_CSOSN_ST_BASE:
             tax_dict["fcpst_value"] = tax_dict["fcpst_base"] * (
                 tax_dict["percent_amount"] / 100
             )
@@ -801,7 +804,6 @@ class Tax(models.Model):
         :param icmssn_range: l10n_br_fiscal.simplified.tax.range record for
             Simples Nacional ICMS calculation.
         :param icms_origin: str, ICMS origin code for the product.
-        :param icms_cst_id: l10n_br_fiscal.cst record, the ICMS CST code.
         :param icms_relief_id: l10n_br_fiscal.icms.relief record, if ICMS relief
             applies.
         :param ind_final: str, indicates if the operation is for a final

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@
 odoo-test-helper  # Needed by spec_driven_model
 pyopenssl==22.1.0
 xmldiff
+# TEMP: fix for partner_bank_id cleared on refund (OCA/bank-payment#1555)
+odoo-addon-account_payment_partner @ git+https://github.com/Engenere/bank-payment@16.0-fix-compute-partner-bank-no-payment-mode#subdirectory=setup/account_payment_partner


### PR DESCRIPTION
## Resumo

O campo `icms_cst_id` era simultaneamente input (`@api.depends` de `_compute_tax_fields`) e output (definido por `_prepare_fields_icms`/`_prepare_fields_icmssn` a partir do resultado da computação). Isso criava um ciclo de dependência auto-referenciante que pode causar comportamento não-determinístico dependendo da ordem de resolução do grafo de computes do ORM.

O CST já é computado internamente por `tax.cst_from_tax()` em `_compute_tax` (tax.py:335), então o parâmetro externo `icms_cst_id` passado para `compute_taxes()` era redundante.

### Mudanças
- `_compute_icms`: usa `tax_dict["cst_id"]` (definido por `_compute_tax`) em vez de `kwargs["icms_cst_id"]` para checks de desoneração ICMS
- `_compute_icmsfcp`: obtém CST de `taxes_dict["icms"/"icmssn"]["cst_id"]` em vez de `kwargs["icms_cst_id"]` para checks de FCP ST
- Remove `icms_cst_id` do `@api.depends` de `_compute_tax_fields`
- Remove parâmetro `icms_cst_id` das chamadas `compute_taxes()`

## Plano de teste
- [ ] Testes `l10n_br_fiscal` passando
- [ ] Testes `l10n_br_account` passando
- [ ] Testes `l10n_br_sale_stock` passando
- [ ] Verificar que `icms_cst_id` continua sendo preenchido corretamente em documentos fiscais (via `_prepare_fields_icms`/`_prepare_fields_icmssn`)