### PR TITLE
[16.0][IMP] l10n_br_fiscal_dfe: add access_key to DFe tree view

### DIFF
--- a/l10n_br_fiscal_dfe/views/dfe_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_views.xml
@@ -52,6 +52,7 @@
         <field name="arch" type="xml">
             <tree create="false">
                 <field name="nsu" />
+                <field name="access_key" />
                 <field name="dfe_nfe_document_type" string="DF-e" />
                 <button
                     string="XML"


### PR DESCRIPTION
## Resumo

Adiciona o campo `access_key` (chave de acesso) na tree view do modelo `l10n_br_fiscal_dfe.dfe`, facilitando a identificação dos documentos diretamente na listagem.