### PR TITLE
[16.0][REF] l10n_br_fiscal_dfe: simplify dfe model and move metadata to document

### DIFF
--- a/l10n_br_fiscal_dfe/controllers/main.py
+++ b/l10n_br_fiscal_dfe/controllers/main.py
@@ -11,16 +11,34 @@ class DfeDocumentBannerController(http.Controller):
     @http.route("/l10n_br_fiscal_dfe/document_banner", auth="user", type="json")
     def document_banner(self):
         company = request.env.company
-        DfeRecord = request.env["l10n_br_fiscal_dfe.dfe"]
         DfeDocument = request.env["l10n_br_fiscal_dfe.document"]
 
-        pending_import_count = DfeRecord.search_count(
+        complete_dfe_docs = DfeDocument.search(
             [
                 ("company_id", "=", company.id),
-                ("dfe_nfe_document_type", "=", "dfe_nfe_complete"),
-                ("imported_document_id", "=", False),
+                ("dfe_ids.dfe_nfe_document_type", "=", "dfe_nfe_complete"),
             ]
         )
+        if complete_dfe_docs:
+            FiscalDoc = request.env["l10n_br_fiscal.document"]
+            imported_keys = set(
+                FiscalDoc.search(
+                    [
+                        (
+                            "document_key",
+                            "in",
+                            complete_dfe_docs.mapped("access_key"),
+                        ),
+                    ]
+                ).mapped("document_key")
+            )
+            pending_import_count = len(
+                complete_dfe_docs.filtered(
+                    lambda doc: doc.access_key not in imported_keys
+                )
+            )
+        else:
+            pending_import_count = 0
 
         today = fields.Date.context_today(DfeDocument)
         today_domain = [

--- a/l10n_br_fiscal_dfe/models/dfe.py
+++ b/l10n_br_fiscal_dfe/models/dfe.py
@@ -74,11 +74,6 @@ class DFe(models.Model):
 
     xml_pretty = fields.Text(string="XML Pretty", compute="_compute_xml_pretty")
 
-    imported_document_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.document",
-        string="Fiscal Document",
-    )
-
     event_type_dfe = fields.Char(string="Event Type")
 
     event_type_dfe_label = fields.Char(
@@ -147,15 +142,12 @@ class DFe(models.Model):
         self.ensure_one()
         try:
             document = self.company_id._dfe_download_document(self.access_key)
-            document_id = self.company_id._dfe_parse_xml_document(document)
+            self.company_id._dfe_parse_xml_document(document)
         except Exception as exc:
             self.company_id._dfe_log(
                 _("Error importing document: \n\n %(error)s", error=exc),
                 log_type="error",
             )
-            return
-        if document_id:
-            self.sudo().imported_document_id = document_id
 
     def import_document_multi(self):
         for rec in self:

--- a/l10n_br_fiscal_dfe/models/dfe.py
+++ b/l10n_br_fiscal_dfe/models/dfe.py
@@ -3,16 +3,24 @@
 import base64
 import logging
 
-from lxml import etree, objectify
+from lxml import etree
 
 from odoo import _, api, fields, models
 
-from ..constants.dfe import (
-    OPERATION_TYPE,
-    SITUACAO_NFE,
-)
+from ..constants.dfe import OPERATION_TYPE
 
 _logger = logging.getLogger(__name__)
+
+EVENT_TYPE_LABELS = {
+    "210200": "Confirmação da Operação",
+    "210210": "Ciência da Operação",
+    "210220": "Desconhecimento da Operação",
+    "210240": "Operação não Realizada",
+    "110110": "Carta de Correção",
+    "110111": "Cancelamento",
+    "110112": "Cancelamento por Substituição",
+    "110140": "EPEC",
+}
 
 DFE_DESCRIPTION_MAP = {
     "procNFe": "XML NF-e completo (procNFe) via distribuição DF-e",
@@ -25,10 +33,7 @@ DFE_DESCRIPTION_MAP = {
 class DFe(models.Model):
     _name = "l10n_br_fiscal_dfe.dfe"
     _description = "DF-e"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "id desc"
-    _rec_name = "display_name"
-    _mail_post_access = "read"
 
     dfe_document_id = fields.Many2one(
         comodel_name="l10n_br_fiscal_dfe.document", string="DF-e Document"
@@ -36,62 +41,21 @@ class DFe(models.Model):
 
     access_key = fields.Char(size=44)
 
-    serie = fields.Char(size=3, index=True)
-
-    document_number = fields.Float(index=True, digits=(18, 0))
-
-    emitter = fields.Char(size=60)
-
-    vat = fields.Char(string="CNPJ/CPF", size=18)
-
     nsu = fields.Char(string="NSU", size=25, index=True)
 
     schema_type = fields.Char(
         help="Type of the DF-e document according to the XML schema.",
     )
 
-    # Saida ou Entrada
     operation_type = fields.Selection(
         selection=OPERATION_TYPE,
     )
-
-    document_amount = fields.Float(
-        string="Document Total Value",
-        readonly=True,
-        digits=(18, 2),
-    )
-
-    ie = fields.Char(string="Inscrição estadual", size=18)
 
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
         default=lambda self: self.env.company,
         readonly=True,
-    )
-
-    emission_datetime = fields.Datetime(
-        string="Emission Date",
-        index=True,
-        default=fields.Datetime.now,
-    )
-
-    inclusion_datetime = fields.Datetime(
-        string="Inclusion Date",
-        index=True,
-        default=fields.Datetime.now,
-    )
-
-    document_state = fields.Selection(
-        selection=SITUACAO_NFE,
-        index=True,
-    )
-
-    cfop_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.cfop",
-        string="CFOPs",
-        compute="_compute_cfop_ids",
-        store=True,
     )
 
     dfe_nfe_document_type = fields.Selection(
@@ -115,7 +79,23 @@ class DFe(models.Model):
         string="Fiscal Document",
     )
 
-    event_type_dfe = fields.Char()
+    event_type_dfe = fields.Char(string="Event Type")
+
+    event_type_dfe_label = fields.Char(
+        string="Event",
+        compute="_compute_event_type_dfe_label",
+    )
+
+    @api.depends("event_type_dfe")
+    def _compute_event_type_dfe_label(self):
+        for rec in self:
+            code = rec.event_type_dfe
+            if not code:
+                rec.event_type_dfe_label = False
+            elif code in EVENT_TYPE_LABELS:
+                rec.event_type_dfe_label = EVENT_TYPE_LABELS[code]
+            else:
+                rec.event_type_dfe_label = _("Other (%(code)s)", code=code)
 
     def name_get(self):
         result = []
@@ -169,8 +149,9 @@ class DFe(models.Model):
             document = self.company_id._dfe_download_document(self.access_key)
             document_id = self.company_id._dfe_parse_xml_document(document)
         except Exception as exc:
-            self.message_post(
-                body=_("Error importing document: \n\n %(error)s", error=exc)
+            self.company_id._dfe_log(
+                _("Error importing document: \n\n %(error)s", error=exc),
+                log_type="error",
             )
             return
         if document_id:
@@ -179,27 +160,6 @@ class DFe(models.Model):
     def import_document_multi(self):
         for rec in self:
             rec.import_document()
-
-    @api.depends("attachment_id")
-    def _compute_cfop_ids(self):
-        Cfop = self.env["l10n_br_fiscal.cfop"]
-        for rec in self:
-            rec.cfop_ids = Cfop
-            if rec.dfe_nfe_document_type != "dfe_nfe_complete":
-                continue
-            data = rec.attachment_id.with_context(bin_size=False).datas
-            if not data:
-                continue
-            try:
-                xml_bytes = base64.b64decode(data)
-                root = objectify.fromstring(xml_bytes)
-                cfop_codes = set()
-                for det in root.NFe.infNFe.det:
-                    cfop_codes.add(str(det.prod.CFOP))
-                if cfop_codes:
-                    rec.cfop_ids = Cfop.search([("code", "in", list(cfop_codes))])
-            except Exception:
-                _logger.debug("Could not extract CFOPs from DFe %s XML", rec.id)
 
     @api.depends("attachment_id")
     def _compute_xml_pretty(self):

--- a/l10n_br_fiscal_dfe/models/dfe_document.py
+++ b/l10n_br_fiscal_dfe/models/dfe_document.py
@@ -1,15 +1,19 @@
 # Copyright (C) 2025-Today - Engenere (<https://engenere.one>).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import base64
+import logging
 import re
 from io import BytesIO
 
 from brazilfiscalreport.danfe import Danfe
+from lxml import objectify
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants.dfe import SITUACAO_NFE
+
+_logger = logging.getLogger(__name__)
 
 
 class L10nBrFiscalDfeDocument(models.Model):
@@ -33,28 +37,21 @@ class L10nBrFiscalDfeDocument(models.Model):
         string="DF-e records",
     )
 
-    emitter = fields.Char(compute="_compute_dfe_info")
+    emitter = fields.Char(size=60)
 
-    vat = fields.Char(related="dfe_ids.vat")
+    vat = fields.Char(string="CNPJ/CPF", size=18)
 
-    document_amount = fields.Float(
-        string="Document Total Value", digits=(18, 2), compute="_compute_dfe_info"
-    )
+    document_amount = fields.Float(string="Document Total Value", digits=(18, 2))
 
     document_state = fields.Selection(
         selection=SITUACAO_NFE,
-        compute="_compute_document_state",
-        store=True,
     )
 
-    document_number = fields.Float(compute="_compute_dfe_info")
+    document_number = fields.Float(digits=(18, 0))
 
-    document_emission_date = fields.Datetime(
-        compute="_compute_document_emission_date",
-        store=True,
-    )
+    document_emission_date = fields.Datetime(string="Emission Date")
 
-    serie = fields.Char(compute="_compute_dfe_info")
+    serie = fields.Char(size=3)
 
     color_status = fields.Selection(
         [
@@ -138,53 +135,40 @@ class L10nBrFiscalDfeDocument(models.Model):
             else:
                 record.is_own_document = False
 
-    @api.depends("dfe_ids.cfop_ids")
+    @api.depends("dfe_ids.attachment_id")
     def _compute_cfop_ids(self):
+        Cfop = self.env["l10n_br_fiscal.cfop"]
         for record in self:
-            record.cfop_ids = record.dfe_ids.mapped("cfop_ids")
+            record.cfop_ids = Cfop
+            complete_dfe = record.dfe_ids.filtered(
+                lambda dfe: dfe.dfe_nfe_document_type == "dfe_nfe_complete"
+            )
+            if not complete_dfe:
+                continue
+            data = complete_dfe[0].attachment_id.with_context(bin_size=False).datas
+            if not data:
+                continue
+            try:
+                xml_bytes = base64.b64decode(data)
+                root = objectify.fromstring(xml_bytes)
+                cfop_codes = set()
+                for det in root.NFe.infNFe.det:
+                    cfop_codes.add(str(det.prod.CFOP))
+                if cfop_codes:
+                    record.cfop_ids = Cfop.search([("code", "in", list(cfop_codes))])
+            except Exception:
+                _logger.debug("Could not extract CFOPs from document %s XML", record.id)
 
-    def _compute_dfe_info(self):
-        for record in self:
-            dfe = record._get_priority_dfe()
-            if dfe:
-                record.emitter = dfe.emitter
-                record.document_amount = dfe.document_amount
-                record.document_number = dfe.document_number
-                record.serie = dfe.serie
-            else:
-                record.emitter = False
-                record.document_amount = 0.0
-                record.document_number = 0.0
-                record.serie = False
+    def _update_metadata(self, vals, is_complete=False):
+        """Update document metadata from parsed XML data.
 
-    def _get_priority_dfe(self):
-        """Return the best DFe record (complete > summary > first)."""
-        self.ensure_one()
-        dfe_ids = self.dfe_ids
-        complete = dfe_ids.filtered(
-            lambda d: d.dfe_nfe_document_type == "dfe_nfe_complete"
-        )
-        summary = dfe_ids.filtered(
-            lambda d: d.dfe_nfe_document_type == "dfe_nfe_summary"
-        )
-        return (
-            (complete and complete[0])
-            or (summary and summary[0])
-            or (dfe_ids and dfe_ids[0])
-            or False
-        )
-
-    @api.depends("dfe_ids.emission_datetime", "dfe_ids.dfe_nfe_document_type")
-    def _compute_document_emission_date(self):
-        for record in self:
-            dfe = record._get_priority_dfe()
-            record.document_emission_date = dfe.emission_datetime if dfe else False
-
-    @api.depends("dfe_ids.document_state", "dfe_ids.dfe_nfe_document_type")
-    def _compute_document_state(self):
-        for record in self:
-            dfe = record._get_priority_dfe()
-            record.document_state = dfe.document_state if dfe else False
+        procNFe (is_complete=True) always overwrites.
+        resNFe only writes if no complete dfe exists yet.
+        """
+        if is_complete or not self.dfe_ids.filtered(
+            lambda dfe: dfe.dfe_nfe_document_type == "dfe_nfe_complete"
+        ):
+            self.sudo().write(vals)
 
     def _compute_manifestation_status(self):
         for record in self:

--- a/l10n_br_fiscal_dfe/models/res_company.py
+++ b/l10n_br_fiscal_dfe/models/res_company.py
@@ -675,6 +675,7 @@ class ResCompany(models.Model):
                     "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_event",
+                    "event_type_dfe": str(root.evento.infEvento.tpEvento),
                 }
             )
         )
@@ -691,12 +692,19 @@ class ResCompany(models.Model):
 
         document = Document.search(domain, limit=1)
         if not document:
-            document = Document.create(
-                {
-                    "access_key": nfe_key,
-                    "company_id": self.id,
-                }
-            )
+            vals = {
+                "access_key": nfe_key,
+                "company_id": self.id,
+            }
+            # Extract baseline metadata from the access key structure:
+            # positions 6-20: CNPJ, 22-25: serie, 25-34: document number
+            key = str(nfe_key)
+            if len(key) == 44:
+                cnpj_digits = key[6:20]
+                vals["vat"] = utils.mask_cnpj(cnpj_digits)
+                vals["serie"] = key[22:25].lstrip("0") or "0"
+                vals["document_number"] = float(key[25:34])
+            document = Document.create(vals)
         return document
 
     def _dfe_download_document(self, nfe_key):

--- a/l10n_br_fiscal_dfe/models/res_company.py
+++ b/l10n_br_fiscal_dfe/models/res_company.py
@@ -177,42 +177,6 @@ class ResCompany(models.Model):
         if earliest and earliest != cron.nextcall:
             cron.sudo().nextcall = earliest
 
-    def _dfe_schedule_next_query(self, status_code, had_exception=False):
-        """Schedule the next DF-e query based on the last response status."""
-        if had_exception:
-            interval = DFE_INTERVAL_ERROR
-        elif status_code == CSTAT_SUCCESS:
-            interval = DFE_INTERVAL_SUCCESS
-        elif status_code == CSTAT_NO_DOCS:
-            interval = DFE_INTERVAL_NO_DOCS
-        elif status_code == CSTAT_CONSUMO_INDEVIDO:
-            interval = DFE_INTERVAL_RATE_LIMITED
-        else:
-            interval = DFE_INTERVAL_NO_DOCS
-        self.dfe_next_query = fields.Datetime.now() + interval
-        self._dfe_sync_cron_nextcall()
-
-    def _dfe_sync_cron_nextcall(self):
-        """Sync cron nextcall to the earliest dfe_next_query across companies."""
-        cron = self.env.ref(
-            "l10n_br_fiscal_dfe.ir_cron_search_dfe_documents",
-            raise_if_not_found=False,
-        )
-        if not cron:
-            return
-        earliest = (
-            self.env["res.company"]
-            .sudo()
-            .search(
-                [("auto_fetch", "=", True), ("dfe_next_query", "!=", False)],
-                order="dfe_next_query asc",
-                limit=1,
-            )
-            .dfe_next_query
-        )
-        if earliest and earliest != cron.nextcall:
-            cron.sudo().nextcall = earliest
-
     def _dfe_get_processor(self):
         self.ensure_one()
         cert = base64.b64decode(self.certificate.file)
@@ -582,7 +546,6 @@ class ResCompany(models.Model):
                 dfe_record = DfeRecord.create(
                     {
                         "nsu": nsu,
-                        "inclusion_datetime": datetime.now(),
                         "company_id": self.id,
                     }
                 )
@@ -600,28 +563,31 @@ class ResCompany(models.Model):
             .sudo()
             .create(
                 {
-                    "document_number": root.NFe.infNFe.ide.nNF,
-                    "emitter": root.NFe.infNFe.emit.xNome,
                     "access_key": nfe_key,
-                    "serie": root.NFe.infNFe.ide.serie,
-                    "operation_type": str(root.NFe.infNFe.ide.tpNF),
-                    "document_amount": root.NFe.infNFe.total.ICMSTot.vNF,
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "ie": root.NFe.infNFe.emit.IE,
-                    "emission_datetime": datetime.strptime(
-                        str(root.NFe.infNFe.ide.dhEmi)[:19],
-                        "%Y-%m-%dT%H:%M:%S",
-                    ),
                     "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_complete",
-                    "document_state": "1",
+                    "operation_type": str(root.NFe.infNFe.ide.tpNF),
                 }
             )
         )
 
         dfe_document.sudo().dfe_ids = [(4, dfe_record.id)]
+        dfe_document._update_metadata(
+            {
+                "emitter": str(root.NFe.infNFe.emit.xNome),
+                "vat": supplier_cnpj,
+                "serie": str(root.NFe.infNFe.ide.serie),
+                "document_number": float(root.NFe.infNFe.ide.nNF),
+                "document_amount": float(root.NFe.infNFe.total.ICMSTot.vNF),
+                "document_emission_date": datetime.strptime(
+                    str(root.NFe.infNFe.ide.dhEmi)[:19],
+                    "%Y-%m-%dT%H:%M:%S",
+                ),
+                "document_state": "1",
+            },
+            is_complete=True,
+        )
         return dfe_record
 
     def _dfe_create_from_resNFe(self, root, nsu):
@@ -635,21 +601,26 @@ class ResCompany(models.Model):
             .create(
                 {
                     "access_key": nfe_key,
-                    "emitter": root.xNome,
-                    "operation_type": str(root.tpNF),
-                    "document_amount": root.vNF,
-                    "document_state": str(root.cSitNFe),
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "ie": root.IE,
-                    "emission_datetime": datetime.strptime(
-                        str(root.dhEmi)[:19], "%Y-%m-%dT%H:%M:%S"
-                    ),
+                    "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_summary",
-                    "nsu": nsu,
+                    "operation_type": str(root.tpNF),
                 }
             )
+        )
+
+        dfe_document.sudo().dfe_ids = [(4, dfe_record.id)]
+        dfe_document._update_metadata(
+            {
+                "emitter": str(root.xNome),
+                "vat": supplier_cnpj,
+                "document_amount": float(root.vNF),
+                "document_emission_date": datetime.strptime(
+                    str(root.dhEmi)[:19], "%Y-%m-%dT%H:%M:%S"
+                ),
+                "document_state": str(root.cSitNFe),
+            },
+            is_complete=False,
         )
 
         if self.auto_manifest_nfe:
@@ -668,13 +639,11 @@ class ResCompany(models.Model):
                 description=f"Auto-manifest ciência: {nfe_key}",
             ).action_confirm()
 
-        dfe_document.sudo().dfe_ids = [(4, dfe_record.id)]
         return dfe_record
 
     def _dfe_create_from_resEvento(self, root, nsu):
         nfe_key = root.chNFe
         dfe_document = self._dfe_get_or_create_document(nfe_key)
-        supplier_cnpj = utils.mask_cnpj("%014d" % root.CNPJ)
 
         dfe_record = (
             self.env["l10n_br_fiscal_dfe.dfe"]
@@ -682,15 +651,10 @@ class ResCompany(models.Model):
             .create(
                 {
                     "access_key": nfe_key,
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "emission_datetime": datetime.strptime(
-                        str(root.dhEvento)[:19], "%Y-%m-%dT%H:%M:%S"
-                    ),
-                    "company_id": self.id,
-                    "event_type_dfe": str(root.tpEvento),
-                    "dfe_nfe_document_type": "dfe_nfe_event",
                     "nsu": nsu,
+                    "company_id": self.id,
+                    "dfe_nfe_document_type": "dfe_nfe_event",
+                    "event_type_dfe": str(root.tpEvento),
                 }
             )
         )
@@ -701,7 +665,6 @@ class ResCompany(models.Model):
     def _dfe_create_from_procEventoNFe(self, root, nsu):
         nfe_key = root.evento.infEvento.chNFe
         dfe_document = self._dfe_get_or_create_document(nfe_key)
-        supplier_cnpj = utils.mask_cnpj("%014d" % root.evento.infEvento.CNPJ)
 
         dfe_record = (
             self.env["l10n_br_fiscal_dfe.dfe"]
@@ -709,14 +672,9 @@ class ResCompany(models.Model):
             .create(
                 {
                     "access_key": nfe_key,
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "emission_datetime": datetime.strptime(
-                        str(root.evento.infEvento.dhEvento)[:19], "%Y-%m-%dT%H:%M:%S"
-                    ),
+                    "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_event",
-                    "nsu": nsu,
                 }
             )
         )

--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -58,7 +58,7 @@ class TestDFe(TransactionCase):
             limit=1,
         )
         self.assertTrue(dfe_record, "procNFe should create a dfe_nfe_complete record")
-        cfop_codes = dfe_record.cfop_ids.mapped("code")
+        cfop_codes = dfe_record.dfe_document_id.cfop_ids.mapped("code")
         self.assertIn("5102", cfop_codes, "CFOP 5102 should be extracted from procNFe")
 
     def test_search_dfe_error_conditions(self):

--- a/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
@@ -58,8 +58,6 @@ class TestNFeDFe(TransactionCase):
         self.assertEqual(
             dfe1.access_key, "31201010588201000105550010038421171838422178"
         )
-        self.assertEqual(dfe1.emitter, "ZAP GRAFICA E EDITORA EIRELI")
-        self.assertEqual(dfe1.vat, "10.588.201/0001-05")
         self.assertEqual(dfe1.dfe_nfe_document_type, "dfe_nfe_summary")
         self.assertEqual(dfe1.nsu, "000000000000200")
         self.assertEqual(
@@ -67,6 +65,8 @@ class TestNFeDFe(TransactionCase):
             "31201010588201000105550010038421171838422178 - Resumo da NF-e",
         )
         self.assertEqual(dfe1.dfe_document_id.color_status, "blue")
+        self.assertEqual(dfe1.dfe_document_id.emitter, "ZAP GRAFICA E EDITORA EIRELI")
+        self.assertEqual(dfe1.dfe_document_id.vat, "10.588.201/0001-05")
         self.assertEqual(
             dfe1.dfe_document_id.display_name,
             "31201010588201000105550010038421171838422178",
@@ -80,10 +80,10 @@ class TestNFeDFe(TransactionCase):
         self.assertEqual(
             dfe2.access_key, "35200159594315000157550010000000012062777161"
         )
-        self.assertEqual(dfe2.vat, "59.594.315/0001-57")
         self.assertEqual(dfe2.dfe_nfe_document_type, "dfe_nfe_complete")
-        self.assertEqual(dfe2.emitter, "TESTE - Simples Nacional")
-        self.assertEqual(dfe2.document_amount, 14.0)
+        self.assertEqual(dfe2.dfe_document_id.emitter, "TESTE - Simples Nacional")
+        self.assertEqual(dfe2.dfe_document_id.document_amount, 14.0)
+        self.assertEqual(dfe2.dfe_document_id.vat, "59.594.315/0001-57")
         self.assertEqual(
             dfe2.dfe_document_id.access_key,
             "35200159594315000157550010000000012062777161",

--- a/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
@@ -36,12 +36,12 @@ class TestNFeDFe(TransactionCase):
         self.company.dfe_import_documents()
 
         self.assertEqual(len(self.company.dfe_ids), 1)
-        dfe_record = self.company.dfe_ids[0]
-        self.assertTrue(dfe_record.imported_document_id)
-        self.assertEqual(
-            dfe_record.imported_document_id.document_key,
-            "35200159594315000157550010000000012062777161",
+        access_key = "35200159594315000157550010000000012062777161"
+        fiscal_doc = self.env["l10n_br_fiscal.document"].search(
+            [("document_key", "=", access_key)], limit=1
         )
+        self.assertTrue(fiscal_doc, "Fiscal document should be created after import")
+        self.assertEqual(fiscal_doc.document_key, access_key)
         self.assertEqual(_mock_post.call_count, 2)
 
     @mock.patch.object(DefaultTransport, "post")

--- a/l10n_br_fiscal_dfe/views/dfe_document_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_document_views.xml
@@ -86,6 +86,7 @@
                             <field name="dfe_ids">
                                 <tree>
                                     <field name="dfe_nfe_document_type" string="DF-e" />
+                                    <field name="event_type_dfe_label" string="Event" />
                                     <field name="nsu" />
                                     <button
                                         string="XML"

--- a/l10n_br_fiscal_dfe/views/dfe_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_views.xml
@@ -16,22 +16,15 @@
                 <separator string="Document Info" />
                 <group>
                     <group>
-                        <field name="document_number" readonly="1" />
                         <field name="nsu" readonly="1" />
-                        <field name="vat" readonly="1" />
-                        <field name="ie" readonly="1" />
-                        <field name="document_amount" widget="monetary" readonly="1" />
-                        <field name="document_state" readonly="1" />
-                        <field name="cfop_ids" readonly="1" widget="many2many_tags" />
+                        <field name="dfe_nfe_document_type" readonly="1" />
+                        <field name="event_type_dfe_label" readonly="1" />
+                        <field name="operation_type" readonly="1" />
                     </group>
                     <group>
                         <field name="company_id" readonly="1" />
                         <field name="imported_document_id" readonly="1" />
-                        <field name="operation_type" readonly="1" />
-                        <field name="inclusion_datetime" readonly="1" />
-                        <field name="emission_datetime" readonly="1" />
                         <field name="attachment_id" readonly="1" />
-                        <field name="display_name" readonly="1" />
                     </group>
                     <label for="xml_pretty" string="XML Attachment" />
                     <field
@@ -60,8 +53,6 @@
                     type="object"
                     icon="fa-download"
                 />
-                <field name="emission_datetime" widget="datetime" string="Emission" />
-                <field name="inclusion_datetime" widget="datetime" string="Inclusion" />
             </tree>
         </field>
     </record>

--- a/l10n_br_fiscal_dfe/views/dfe_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_views.xml
@@ -23,7 +23,7 @@
                     </group>
                     <group>
                         <field name="company_id" readonly="1" />
-                        <field name="imported_document_id" readonly="1" />
+                        <field name="dfe_document_id" readonly="1" />
                         <field name="attachment_id" readonly="1" />
                     </group>
                     <label for="xml_pretty" string="XML Attachment" />

--- a/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
+++ b/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
@@ -75,6 +75,6 @@ class DFeSpecificSearchWizard(models.TransientModel):
                 "title": _("Success"),
                 "message": _("Specific search triggered successfully"),
                 "type": "success",
-                "next": {"type": "ir.actions.act_window_close"},
+                "next": {"type": "ir.actions.client", "tag": "reload"},
             },
         }

--- a/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
+++ b/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
@@ -60,6 +60,31 @@ class DFeSpecificSearchWizard(models.TransientModel):
         except ValueError as exc:
             raise UserError(str(exc)) from exc
 
+    def _validate_nsu(self, nsu):
+        """Validate NSU value and check if it already exists."""
+        if not nsu or not nsu.strip():
+            raise UserError(_("Please enter an NSU."))
+        digits_only = re.sub(r"[^0-9]", "", nsu)
+        if not digits_only:
+            raise UserError(_("NSU must contain only numbers."))
+        if all(char == "0" for char in digits_only):
+            raise UserError(_("NSU cannot be zero."))
+        existing = self.env["l10n_br_fiscal_dfe.dfe"].search(
+            [
+                ("nsu", "=", digits_only.zfill(15)),
+                ("company_id", "=", self.company_id.id),
+            ],
+            limit=1,
+        )
+        if existing:
+            raise UserError(
+                _(
+                    "NSU %(nsu)s already exists in the database (DF-e #%(dfe_id)s).",
+                    nsu=nsu,
+                    dfe_id=existing.id,
+                )
+            )
+
     def action_confirm_search(self):
         self.ensure_one()
         if self.search_type == "access_key":
@@ -67,6 +92,7 @@ class DFeSpecificSearchWizard(models.TransientModel):
             self._validate_access_key(access_key)
             self.company_id._dfe_search_specific_document(access_key=access_key)
         else:
+            self._validate_nsu(self.nsu)
             self.company_id._dfe_search_specific_document(nsu=self.nsu)
         return {
             "type": "ir.actions.client",


### PR DESCRIPTION
## Resumo

Refatoração do modelo `l10n_br_fiscal_dfe.dfe` para simplificá-lo ao mínimo necessário (NSU + XML), movendo os metadados parseados para o modelo `dfe_document`.

### O que muda

**Modelo `dfe` (simplificado):**
- Removidos campos de metadado que eram duplicados: `emitter`, `vat`, `serie`, `document_number`, `document_amount`, `emission_datetime`, `document_state`, `inclusion_datetime`, `ie`, `cfop_ids`
- Removidas heranças `mail.thread` e `mail.activity.mixin` (overhead desnecessário)
- `message_post` de erro substituído por `_dfe_log` no distribution log
- `event_type_dfe` mantido como `Char` (aceita qualquer código da SEFAZ) + campo computed `event_type_dfe_label` com labels legíveis e fallback para códigos desconhecidos

**Modelo `dfe_document` (metadados stored):**
- Campos `emitter`, `vat`, `serie`, `document_number`, `document_amount`, `document_emission_date`, `document_state` agora são stored (não computed)
- Novo método `_update_metadata(vals, is_complete)`: procNFe sempre sobrescreve, resNFe só escreve se não há completa
- `cfop_ids` computed diretamente do XML do attachment
- Removidos `_compute_dfe_info`, `_compute_document_emission_date`, `_compute_document_state`, `_get_priority_dfe`

**Bug fix em `res_company`:**
- Removidas definições duplicadas de `_dfe_schedule_next_query` e `_dfe_sync_cron_nextcall`

## Solução

Os metadados que antes eram escritos no `dfe` e lidos de volta pelo `document` via computed fields agora são escritos diretamente no `document` no momento do processamento da distribuição, via `_update_metadata()`. O modelo `dfe` fica lean: apenas `access_key`, `nsu`, `company_id`, `schema_type`, `operation_type`, `dfe_nfe_document_type`, `event_type_dfe`, `attachment_id`, `imported_document_id`.

Saldo: **-97 linhas** (125 adicionadas, 222 removidas).
Testes: 40/40 passando.