### PR TITLE
[16.0][IMP] l10n_br_fiscal_dfe: improve DF-e distribution (rebased)

### DIFF
--- a/l10n_br_fiscal_dfe/controllers/main.py
+++ b/l10n_br_fiscal_dfe/controllers/main.py
@@ -11,16 +11,34 @@ class DfeDocumentBannerController(http.Controller):
     @http.route("/l10n_br_fiscal_dfe/document_banner", auth="user", type="json")
     def document_banner(self):
         company = request.env.company
-        DfeRecord = request.env["l10n_br_fiscal_dfe.dfe"]
         DfeDocument = request.env["l10n_br_fiscal_dfe.document"]
 
-        pending_import_count = DfeRecord.search_count(
+        complete_dfe_docs = DfeDocument.search(
             [
                 ("company_id", "=", company.id),
-                ("dfe_nfe_document_type", "=", "dfe_nfe_complete"),
-                ("imported_document_id", "=", False),
+                ("dfe_ids.dfe_nfe_document_type", "=", "dfe_nfe_complete"),
             ]
         )
+        if complete_dfe_docs:
+            FiscalDoc = request.env["l10n_br_fiscal.document"]
+            imported_keys = set(
+                FiscalDoc.search(
+                    [
+                        (
+                            "document_key",
+                            "in",
+                            complete_dfe_docs.mapped("access_key"),
+                        ),
+                    ]
+                ).mapped("document_key")
+            )
+            pending_import_count = len(
+                complete_dfe_docs.filtered(
+                    lambda doc: doc.access_key not in imported_keys
+                )
+            )
+        else:
+            pending_import_count = 0
 
         today = fields.Date.context_today(DfeDocument)
         today_domain = [

--- a/l10n_br_fiscal_dfe/i18n/pt_BR.po
+++ b/l10n_br_fiscal_dfe/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-19 16:55+0000\n"
-"PO-Revision-Date: 2026-02-19 16:55+0000\n"
+"POT-Creation-Date: 2026-02-20 18:13+0000\n"
+"PO-Revision-Date: 2026-02-20 18:13+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: pt_BR\n"
@@ -173,7 +173,6 @@ msgstr "Já existe um DF-e com esta chave de acesso para esta empresa."
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_l10n_br_fiscal_dfe_dfe__access_key
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_l10n_br_fiscal_dfe_document__access_key
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.dfe_form
-#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_form
 msgid "Access Key"
 msgstr "Chave de Acesso"
 
@@ -280,6 +279,11 @@ msgstr "Cancelada"
 #. module: l10n_br_fiscal_dfe
 #: model:ir.model.fields.selection,name:l10n_br_fiscal_dfe.selection__l10n_br_fiscal_dfe_document__color_status__muted
 msgid "Cancelada/Denegada"
+msgstr "Cancelada/Denegada"
+
+#. module: l10n_br_fiscal_dfe
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_search
+msgid "Cancelled/Denied"
 msgstr "Cancelada/Denegada"
 
 #. module: l10n_br_fiscal_dfe
@@ -404,9 +408,15 @@ msgid "DF-e Notification"
 msgstr "Notificação DF-e"
 
 #. module: l10n_br_fiscal_dfe
+#: model:ir.ui.menu,name:l10n_br_fiscal_dfe.dfe_queries_menu
+msgid "DF-e Queries"
+msgstr "Consultas DF-e"
+
+#. module: l10n_br_fiscal_dfe
 #: model:ir.actions.act_window,name:l10n_br_fiscal_dfe.dfe_action
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_res_company__dfe_ids
 #: model:ir.ui.menu,name:l10n_br_fiscal_dfe.dfe_record_menu
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_form
 msgid "DF-e Records"
 msgstr "Registros DF-e"
 
@@ -440,13 +450,6 @@ msgstr "A distribuição DF-e não será consultada antes deste horário."
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_l10n_br_fiscal_dfe_document__dfe_ids
 msgid "DF-e records"
 msgstr "Registros DF-e"
-
-#. module: l10n_br_fiscal_dfe
-#. odoo-python
-#: code:addons/l10n_br_fiscal_dfe/models/res_company.py:0
-#, python-format
-msgid "DF-e: new documents found for %s"
-msgstr "DF-e: novos documentos encontrados para %s"
 
 #. module: l10n_br_fiscal_dfe
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.dfe_distribution_log_form
@@ -504,13 +507,17 @@ msgstr ""
 "maxNSU=%(mx)s)"
 
 #. module: l10n_br_fiscal_dfe
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_form
+msgid "Document"
+msgstr "Documento"
+
+#. module: l10n_br_fiscal_dfe
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_l10n_br_fiscal_dfe_document__document_emission_date
 msgid "Document Emission Date"
 msgstr "Data de Emissão do Documento"
 
 #. module: l10n_br_fiscal_dfe
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.dfe_form
-#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_form
 msgid "Document Info"
 msgstr "Informações do Documento"
 
@@ -553,6 +560,7 @@ msgstr "Data de Emissão"
 #. module: l10n_br_fiscal_dfe
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_l10n_br_fiscal_dfe_dfe__emitter
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_l10n_br_fiscal_dfe_document__emitter
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_form
 msgid "Emitter"
 msgstr "Emitente"
 
@@ -810,6 +818,7 @@ msgid "Manifest"
 msgstr "Manifestar"
 
 #. module: l10n_br_fiscal_dfe
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_form
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_tree
 msgid "Manifestation"
 msgstr "Manifestação"
@@ -998,12 +1007,6 @@ msgstr ""
 "Receba notificações na caixa de entrada quando a distribuição DF-e encontrar novos documentos."
 
 #. module: l10n_br_fiscal_dfe
-#: model:ir.actions.act_window,name:l10n_br_fiscal_dfe.dfe_document_action
-#: model:ir.ui.menu,name:l10n_br_fiscal_dfe.dfe_document_menu
-msgid "Received NF-es"
-msgstr "NF-es Recebidas"
-
-#. module: l10n_br_fiscal_dfe
 #: model:ir.model,name:l10n_br_fiscal_dfe.model_l10n_br_nfe_md_event
 msgid "Recipient Manifestation"
 msgstr "Manifestação do Destinatário"
@@ -1057,6 +1060,11 @@ msgid "Search"
 msgstr "Pesquisar"
 
 #. module: l10n_br_fiscal_dfe
+#: model:ir.actions.server,name:l10n_br_fiscal_dfe.action_server_search_all_dfe
+msgid "Search All DF-e"
+msgstr "Pesquisar Todos os DF-e"
+
+#. module: l10n_br_fiscal_dfe
 #: model:ir.model.fields,field_description:l10n_br_fiscal_dfe.field_dfe_specific_search_wizard__search_type
 msgid "Search Type"
 msgstr "Tipo de Pesquisa"
@@ -1105,6 +1113,11 @@ msgstr "Pesquisa Específica de DF-e"
 #, python-format
 msgid "Specific Document Search"
 msgstr "Pesquisa Específica de Documento"
+
+#. module: l10n_br_fiscal_dfe
+#: model:ir.actions.server,name:l10n_br_fiscal_dfe.action_server_specific_search_dfe
+msgid "Specific Search DF-e"
+msgstr "Pesquisa Específica de DF-e"
 
 #. module: l10n_br_fiscal_dfe
 #. odoo-python
@@ -1159,6 +1172,12 @@ msgstr "Sucesso"
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_search
 msgid "Summary"
 msgstr "Resumo"
+
+#. module: l10n_br_fiscal_dfe
+#: model:ir.actions.act_window,name:l10n_br_fiscal_dfe.dfe_document_action
+#: model:ir.ui.menu,name:l10n_br_fiscal_dfe.dfe_document_menu
+msgid "Third-party NF-e"
+msgstr "NF-e de Terceiros"
 
 #. module: l10n_br_fiscal_dfe
 #: model:ir.model.fields.selection,name:l10n_br_fiscal_dfe.selection__res_users__dfe_notification__third_party
@@ -1249,17 +1268,3 @@ msgstr "XML Formatado"
 #, python-format
 msgid "You can only import the NF-e when the DF-e is completed."
 msgstr "Você só pode importar a NF-e quando o DF-e estiver completo."
-
-#. module: l10n_br_fiscal_dfe
-#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.dfe_document_banner
-msgid "own"
-msgstr "próprios"
-
-#. module: l10n_br_fiscal_dfe
-#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.dfe_document_banner
-msgid ""
-"third-party\n"
-"                            ·"
-msgstr ""
-"terceiros\n"
-"                            ·"

--- a/l10n_br_fiscal_dfe/i18n/pt_BR.po
+++ b/l10n_br_fiscal_dfe/i18n/pt_BR.po
@@ -932,6 +932,13 @@ msgid "No DF-e with 'DF-e complete' type found."
 msgstr "Nenhum DF-e do tipo 'DF-e completo' encontrado."
 
 #. module: l10n_br_fiscal_dfe
+#. odoo-python
+#: code:addons/l10n_br_fiscal_dfe/models/res_company.py:0
+#, python-format
+msgid "No documents found: %(code)s - %(message)s"
+msgstr "Nenhum documento encontrado: %(code)s - %(message)s"
+
+#. module: l10n_br_fiscal_dfe
 #: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.l10n_br_fiscal_dfe_document_search
 msgid "No Partner"
 msgstr "Sem Parceiro"
@@ -1164,6 +1171,8 @@ msgstr ""
 #. module: l10n_br_fiscal_dfe
 #. odoo-python
 #: code:addons/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py:0
+#: model:ir.model.fields.selection,name:l10n_br_fiscal_dfe.selection__l10n_br_fiscal_dfe_distribution_log__log_type__success
+#: model_terms:ir.ui.view,arch_db:l10n_br_fiscal_dfe.dfe_distribution_log_search
 #, python-format
 msgid "Success"
 msgstr "Sucesso"

--- a/l10n_br_fiscal_dfe/models/dfe.py
+++ b/l10n_br_fiscal_dfe/models/dfe.py
@@ -74,11 +74,6 @@ class DFe(models.Model):
 
     xml_pretty = fields.Text(string="XML Pretty", compute="_compute_xml_pretty")
 
-    imported_document_id = fields.Many2one(
-        comodel_name="l10n_br_fiscal.document",
-        string="Fiscal Document",
-    )
-
     event_type_dfe = fields.Char(string="Event Type")
 
     event_type_dfe_label = fields.Char(
@@ -147,15 +142,12 @@ class DFe(models.Model):
         self.ensure_one()
         try:
             document = self.company_id._dfe_download_document(self.access_key)
-            document_id = self.company_id._dfe_parse_xml_document(document)
+            self.company_id._dfe_parse_xml_document(document)
         except Exception as exc:
             self.company_id._dfe_log(
                 _("Error importing document: \n\n %(error)s", error=exc),
                 log_type="error",
             )
-            return
-        if document_id:
-            self.sudo().imported_document_id = document_id
 
     def import_document_multi(self):
         for rec in self:

--- a/l10n_br_fiscal_dfe/models/dfe.py
+++ b/l10n_br_fiscal_dfe/models/dfe.py
@@ -3,16 +3,24 @@
 import base64
 import logging
 
-from lxml import etree, objectify
+from lxml import etree
 
 from odoo import _, api, fields, models
 
-from ..constants.dfe import (
-    OPERATION_TYPE,
-    SITUACAO_NFE,
-)
+from ..constants.dfe import OPERATION_TYPE
 
 _logger = logging.getLogger(__name__)
+
+EVENT_TYPE_LABELS = {
+    "210200": "Confirmação da Operação",
+    "210210": "Ciência da Operação",
+    "210220": "Desconhecimento da Operação",
+    "210240": "Operação não Realizada",
+    "110110": "Carta de Correção",
+    "110111": "Cancelamento",
+    "110112": "Cancelamento por Substituição",
+    "110140": "EPEC",
+}
 
 DFE_DESCRIPTION_MAP = {
     "procNFe": "XML NF-e completo (procNFe) via distribuição DF-e",
@@ -25,10 +33,7 @@ DFE_DESCRIPTION_MAP = {
 class DFe(models.Model):
     _name = "l10n_br_fiscal_dfe.dfe"
     _description = "DF-e"
-    _inherit = ["mail.thread", "mail.activity.mixin"]
     _order = "id desc"
-    _rec_name = "display_name"
-    _mail_post_access = "read"
 
     dfe_document_id = fields.Many2one(
         comodel_name="l10n_br_fiscal_dfe.document", string="DF-e Document"
@@ -36,62 +41,21 @@ class DFe(models.Model):
 
     access_key = fields.Char(size=44)
 
-    serie = fields.Char(size=3, index=True)
-
-    document_number = fields.Float(index=True, digits=(18, 0))
-
-    emitter = fields.Char(size=60)
-
-    vat = fields.Char(string="CNPJ/CPF", size=18)
-
     nsu = fields.Char(string="NSU", size=25, index=True)
 
     schema_type = fields.Char(
         help="Type of the DF-e document according to the XML schema.",
     )
 
-    # Saida ou Entrada
     operation_type = fields.Selection(
         selection=OPERATION_TYPE,
     )
-
-    document_amount = fields.Float(
-        string="Document Total Value",
-        readonly=True,
-        digits=(18, 2),
-    )
-
-    ie = fields.Char(string="Inscrição estadual", size=18)
 
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
         default=lambda self: self.env.company,
         readonly=True,
-    )
-
-    emission_datetime = fields.Datetime(
-        string="Emission Date",
-        index=True,
-        default=fields.Datetime.now,
-    )
-
-    inclusion_datetime = fields.Datetime(
-        string="Inclusion Date",
-        index=True,
-        default=fields.Datetime.now,
-    )
-
-    document_state = fields.Selection(
-        selection=SITUACAO_NFE,
-        index=True,
-    )
-
-    cfop_ids = fields.Many2many(
-        comodel_name="l10n_br_fiscal.cfop",
-        string="CFOPs",
-        compute="_compute_cfop_ids",
-        store=True,
     )
 
     dfe_nfe_document_type = fields.Selection(
@@ -115,7 +79,23 @@ class DFe(models.Model):
         string="Fiscal Document",
     )
 
-    event_type_dfe = fields.Char()
+    event_type_dfe = fields.Char(string="Event Type")
+
+    event_type_dfe_label = fields.Char(
+        string="Event",
+        compute="_compute_event_type_dfe_label",
+    )
+
+    @api.depends("event_type_dfe")
+    def _compute_event_type_dfe_label(self):
+        for rec in self:
+            code = rec.event_type_dfe
+            if not code:
+                rec.event_type_dfe_label = False
+            elif code in EVENT_TYPE_LABELS:
+                rec.event_type_dfe_label = EVENT_TYPE_LABELS[code]
+            else:
+                rec.event_type_dfe_label = _("Other (%(code)s)", code=code)
 
     def name_get(self):
         result = []
@@ -169,8 +149,9 @@ class DFe(models.Model):
             document = self.company_id._dfe_download_document(self.access_key)
             document_id = self.company_id._dfe_parse_xml_document(document)
         except Exception as exc:
-            self.message_post(
-                body=_("Error importing document: \n\n %(error)s", error=exc)
+            self.company_id._dfe_log(
+                _("Error importing document: \n\n %(error)s", error=exc),
+                log_type="error",
             )
             return
         if document_id:
@@ -179,27 +160,6 @@ class DFe(models.Model):
     def import_document_multi(self):
         for rec in self:
             rec.import_document()
-
-    @api.depends("attachment_id")
-    def _compute_cfop_ids(self):
-        Cfop = self.env["l10n_br_fiscal.cfop"]
-        for rec in self:
-            rec.cfop_ids = Cfop
-            if rec.dfe_nfe_document_type != "dfe_nfe_complete":
-                continue
-            data = rec.attachment_id.with_context(bin_size=False).datas
-            if not data:
-                continue
-            try:
-                xml_bytes = base64.b64decode(data)
-                root = objectify.fromstring(xml_bytes)
-                cfop_codes = set()
-                for det in root.NFe.infNFe.det:
-                    cfop_codes.add(str(det.prod.CFOP))
-                if cfop_codes:
-                    rec.cfop_ids = Cfop.search([("code", "in", list(cfop_codes))])
-            except Exception:
-                _logger.debug("Could not extract CFOPs from DFe %s XML", rec.id)
 
     @api.depends("attachment_id")
     def _compute_xml_pretty(self):

--- a/l10n_br_fiscal_dfe/models/dfe_distribution_log.py
+++ b/l10n_br_fiscal_dfe/models/dfe_distribution_log.py
@@ -18,6 +18,7 @@ class DfeDistributionLog(models.Model):
 
     log_type = fields.Selection(
         selection=[
+            ("success", "Success"),
             ("info", "Info"),
             ("warning", "Warning"),
             ("error", "Error"),

--- a/l10n_br_fiscal_dfe/models/dfe_document.py
+++ b/l10n_br_fiscal_dfe/models/dfe_document.py
@@ -1,15 +1,19 @@
 # Copyright (C) 2025-Today - Engenere (<https://engenere.one>).
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import base64
+import logging
 import re
 from io import BytesIO
 
 from brazilfiscalreport.danfe import Danfe
+from lxml import objectify
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from ..constants.dfe import SITUACAO_NFE
+
+_logger = logging.getLogger(__name__)
 
 
 class L10nBrFiscalDfeDocument(models.Model):
@@ -33,28 +37,21 @@ class L10nBrFiscalDfeDocument(models.Model):
         string="DF-e records",
     )
 
-    emitter = fields.Char(compute="_compute_dfe_info")
+    emitter = fields.Char(size=60)
 
-    vat = fields.Char(related="dfe_ids.vat")
+    vat = fields.Char(string="CNPJ/CPF", size=18)
 
-    document_amount = fields.Float(
-        string="Document Total Value", digits=(18, 2), compute="_compute_dfe_info"
-    )
+    document_amount = fields.Float(string="Document Total Value", digits=(18, 2))
 
     document_state = fields.Selection(
         selection=SITUACAO_NFE,
-        compute="_compute_document_state",
-        store=True,
     )
 
-    document_number = fields.Float(compute="_compute_dfe_info")
+    document_number = fields.Float(digits=(18, 0))
 
-    document_emission_date = fields.Datetime(
-        compute="_compute_document_emission_date",
-        store=True,
-    )
+    document_emission_date = fields.Datetime(string="Emission Date")
 
-    serie = fields.Char(compute="_compute_dfe_info")
+    serie = fields.Char(size=3)
 
     color_status = fields.Selection(
         [
@@ -138,53 +135,40 @@ class L10nBrFiscalDfeDocument(models.Model):
             else:
                 record.is_own_document = False
 
-    @api.depends("dfe_ids.cfop_ids")
+    @api.depends("dfe_ids.attachment_id")
     def _compute_cfop_ids(self):
+        Cfop = self.env["l10n_br_fiscal.cfop"]
         for record in self:
-            record.cfop_ids = record.dfe_ids.mapped("cfop_ids")
+            record.cfop_ids = Cfop
+            complete_dfe = record.dfe_ids.filtered(
+                lambda dfe: dfe.dfe_nfe_document_type == "dfe_nfe_complete"
+            )
+            if not complete_dfe:
+                continue
+            data = complete_dfe[0].attachment_id.with_context(bin_size=False).datas
+            if not data:
+                continue
+            try:
+                xml_bytes = base64.b64decode(data)
+                root = objectify.fromstring(xml_bytes)
+                cfop_codes = set()
+                for det in root.NFe.infNFe.det:
+                    cfop_codes.add(str(det.prod.CFOP))
+                if cfop_codes:
+                    record.cfop_ids = Cfop.search([("code", "in", list(cfop_codes))])
+            except Exception:
+                _logger.debug("Could not extract CFOPs from document %s XML", record.id)
 
-    def _compute_dfe_info(self):
-        for record in self:
-            dfe = record._get_priority_dfe()
-            if dfe:
-                record.emitter = dfe.emitter
-                record.document_amount = dfe.document_amount
-                record.document_number = dfe.document_number
-                record.serie = dfe.serie
-            else:
-                record.emitter = False
-                record.document_amount = 0.0
-                record.document_number = 0.0
-                record.serie = False
+    def _update_metadata(self, vals, is_complete=False):
+        """Update document metadata from parsed XML data.
 
-    def _get_priority_dfe(self):
-        """Return the best DFe record (complete > summary > first)."""
-        self.ensure_one()
-        dfe_ids = self.dfe_ids
-        complete = dfe_ids.filtered(
-            lambda d: d.dfe_nfe_document_type == "dfe_nfe_complete"
-        )
-        summary = dfe_ids.filtered(
-            lambda d: d.dfe_nfe_document_type == "dfe_nfe_summary"
-        )
-        return (
-            (complete and complete[0])
-            or (summary and summary[0])
-            or (dfe_ids and dfe_ids[0])
-            or False
-        )
-
-    @api.depends("dfe_ids.emission_datetime", "dfe_ids.dfe_nfe_document_type")
-    def _compute_document_emission_date(self):
-        for record in self:
-            dfe = record._get_priority_dfe()
-            record.document_emission_date = dfe.emission_datetime if dfe else False
-
-    @api.depends("dfe_ids.document_state", "dfe_ids.dfe_nfe_document_type")
-    def _compute_document_state(self):
-        for record in self:
-            dfe = record._get_priority_dfe()
-            record.document_state = dfe.document_state if dfe else False
+        procNFe (is_complete=True) always overwrites.
+        resNFe only writes if no complete dfe exists yet.
+        """
+        if is_complete or not self.dfe_ids.filtered(
+            lambda dfe: dfe.dfe_nfe_document_type == "dfe_nfe_complete"
+        ):
+            self.sudo().write(vals)
 
     def _compute_manifestation_status(self):
         for record in self:

--- a/l10n_br_fiscal_dfe/models/res_company.py
+++ b/l10n_br_fiscal_dfe/models/res_company.py
@@ -675,6 +675,7 @@ class ResCompany(models.Model):
                     "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_event",
+                    "event_type_dfe": str(root.evento.infEvento.tpEvento),
                 }
             )
         )
@@ -691,12 +692,19 @@ class ResCompany(models.Model):
 
         document = Document.search(domain, limit=1)
         if not document:
-            document = Document.create(
-                {
-                    "access_key": nfe_key,
-                    "company_id": self.id,
-                }
-            )
+            vals = {
+                "access_key": nfe_key,
+                "company_id": self.id,
+            }
+            # Extract baseline metadata from the access key structure:
+            # positions 6-20: CNPJ, 22-25: serie, 25-34: document number
+            key = str(nfe_key)
+            if len(key) == 44:
+                cnpj_digits = key[6:20]
+                vals["vat"] = utils.mask_cnpj(cnpj_digits)
+                vals["serie"] = key[22:25].lstrip("0") or "0"
+                vals["document_number"] = float(key[25:34])
+            document = Document.create(vals)
         return document
 
     def _dfe_download_document(self, nfe_key):

--- a/l10n_br_fiscal_dfe/models/res_company.py
+++ b/l10n_br_fiscal_dfe/models/res_company.py
@@ -323,11 +323,8 @@ class ResCompany(models.Model):
 
         last_query_time = None
         last_result = False
-        existing_doc_ids = set(
-            self.env["l10n_br_fiscal_dfe.document"]
-            .search([("company_id", "=", self.id)])
-            .ids
-        )
+        Document = self.env["l10n_br_fiscal_dfe.document"].sudo()
+        existing_doc_ids = set(Document.search([("company_id", "=", self.id)]).ids)
         while True:
             try:
                 result = self._dfe_consultar_distribuicao(
@@ -379,14 +376,10 @@ class ResCompany(models.Model):
                 break
 
         # Notify opted-in users about newly found documents
-        current_doc_ids = set(
-            self.env["l10n_br_fiscal_dfe.document"]
-            .search([("company_id", "=", self.id)])
-            .ids
-        )
+        current_doc_ids = set(Document.search([("company_id", "=", self.id)]).ids)
         new_doc_ids = current_doc_ids - existing_doc_ids
         if new_doc_ids:
-            new_documents = self.env["l10n_br_fiscal_dfe.document"].browse(new_doc_ids)
+            new_documents = Document.browse(new_doc_ids)
             self._dfe_notify_users(new_documents)
 
         last_resp = last_result.resposta if last_result else False
@@ -434,6 +427,7 @@ class ResCompany(models.Model):
             else "/web#model=l10n_br_fiscal_dfe.document"
         )
 
+        company = self
         for user in users:
             pref = user.dfe_notification
             if pref == "own" and not own_count:
@@ -441,12 +435,19 @@ class ResCompany(models.Model):
             if pref == "third_party" and not third_party_count:
                 continue
 
+            # Rebind self so _() picks up the user's language from
+            # self.env.context (GettextAlias inspects the caller's frame).
+            self = company.with_context(lang=user.lang or "pt_BR")
+
             parts = []
             if pref in ("all", "own") and own_count:
                 parts.append(_("%(count)s own document(s)", count=own_count))
             if pref in ("all", "third_party") and third_party_count:
                 parts.append(
-                    _("%(count)s third-party document(s)", count=third_party_count)
+                    _(
+                        "%(count)s third-party document(s)",
+                        count=third_party_count,
+                    )
                 )
             body_text = ", ".join(parts)
             body = _(
@@ -455,9 +456,8 @@ class ResCompany(models.Model):
                 summary=body_text,
                 url=action_url,
             )
-            self.env["mail.thread"].message_notify(
+            self.env["mail.thread"].sudo().message_notify(
                 partner_ids=user.partner_id.ids,
-                subject=_("DF-e: new documents found for %s", self.name),
                 body=body,
             )
 

--- a/l10n_br_fiscal_dfe/models/res_company.py
+++ b/l10n_br_fiscal_dfe/models/res_company.py
@@ -177,42 +177,6 @@ class ResCompany(models.Model):
         if earliest and earliest != cron.nextcall:
             cron.sudo().nextcall = earliest
 
-    def _dfe_schedule_next_query(self, status_code, had_exception=False):
-        """Schedule the next DF-e query based on the last response status."""
-        if had_exception:
-            interval = DFE_INTERVAL_ERROR
-        elif status_code == CSTAT_SUCCESS:
-            interval = DFE_INTERVAL_SUCCESS
-        elif status_code == CSTAT_NO_DOCS:
-            interval = DFE_INTERVAL_NO_DOCS
-        elif status_code == CSTAT_CONSUMO_INDEVIDO:
-            interval = DFE_INTERVAL_RATE_LIMITED
-        else:
-            interval = DFE_INTERVAL_NO_DOCS
-        self.dfe_next_query = fields.Datetime.now() + interval
-        self._dfe_sync_cron_nextcall()
-
-    def _dfe_sync_cron_nextcall(self):
-        """Sync cron nextcall to the earliest dfe_next_query across companies."""
-        cron = self.env.ref(
-            "l10n_br_fiscal_dfe.ir_cron_search_dfe_documents",
-            raise_if_not_found=False,
-        )
-        if not cron:
-            return
-        earliest = (
-            self.env["res.company"]
-            .sudo()
-            .search(
-                [("auto_fetch", "=", True), ("dfe_next_query", "!=", False)],
-                order="dfe_next_query asc",
-                limit=1,
-            )
-            .dfe_next_query
-        )
-        if earliest and earliest != cron.nextcall:
-            cron.sudo().nextcall = earliest
-
     def _dfe_get_processor(self):
         self.ensure_one()
         cert = base64.b64decode(self.certificate.file)
@@ -582,7 +546,6 @@ class ResCompany(models.Model):
                 dfe_record = DfeRecord.create(
                     {
                         "nsu": nsu,
-                        "inclusion_datetime": datetime.now(),
                         "company_id": self.id,
                     }
                 )
@@ -600,28 +563,31 @@ class ResCompany(models.Model):
             .sudo()
             .create(
                 {
-                    "document_number": root.NFe.infNFe.ide.nNF,
-                    "emitter": root.NFe.infNFe.emit.xNome,
                     "access_key": nfe_key,
-                    "serie": root.NFe.infNFe.ide.serie,
-                    "operation_type": str(root.NFe.infNFe.ide.tpNF),
-                    "document_amount": root.NFe.infNFe.total.ICMSTot.vNF,
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "ie": root.NFe.infNFe.emit.IE,
-                    "emission_datetime": datetime.strptime(
-                        str(root.NFe.infNFe.ide.dhEmi)[:19],
-                        "%Y-%m-%dT%H:%M:%S",
-                    ),
                     "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_complete",
-                    "document_state": "1",
+                    "operation_type": str(root.NFe.infNFe.ide.tpNF),
                 }
             )
         )
 
         dfe_document.sudo().dfe_ids = [(4, dfe_record.id)]
+        dfe_document._update_metadata(
+            {
+                "emitter": str(root.NFe.infNFe.emit.xNome),
+                "vat": supplier_cnpj,
+                "serie": str(root.NFe.infNFe.ide.serie),
+                "document_number": float(root.NFe.infNFe.ide.nNF),
+                "document_amount": float(root.NFe.infNFe.total.ICMSTot.vNF),
+                "document_emission_date": datetime.strptime(
+                    str(root.NFe.infNFe.ide.dhEmi)[:19],
+                    "%Y-%m-%dT%H:%M:%S",
+                ),
+                "document_state": "1",
+            },
+            is_complete=True,
+        )
         return dfe_record
 
     def _dfe_create_from_resNFe(self, root, nsu):
@@ -635,21 +601,26 @@ class ResCompany(models.Model):
             .create(
                 {
                     "access_key": nfe_key,
-                    "emitter": root.xNome,
-                    "operation_type": str(root.tpNF),
-                    "document_amount": root.vNF,
-                    "document_state": str(root.cSitNFe),
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "ie": root.IE,
-                    "emission_datetime": datetime.strptime(
-                        str(root.dhEmi)[:19], "%Y-%m-%dT%H:%M:%S"
-                    ),
+                    "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_summary",
-                    "nsu": nsu,
+                    "operation_type": str(root.tpNF),
                 }
             )
+        )
+
+        dfe_document.sudo().dfe_ids = [(4, dfe_record.id)]
+        dfe_document._update_metadata(
+            {
+                "emitter": str(root.xNome),
+                "vat": supplier_cnpj,
+                "document_amount": float(root.vNF),
+                "document_emission_date": datetime.strptime(
+                    str(root.dhEmi)[:19], "%Y-%m-%dT%H:%M:%S"
+                ),
+                "document_state": str(root.cSitNFe),
+            },
+            is_complete=False,
         )
 
         if self.auto_manifest_nfe:
@@ -668,13 +639,11 @@ class ResCompany(models.Model):
                 description=f"Auto-manifest ciência: {nfe_key}",
             ).action_confirm()
 
-        dfe_document.sudo().dfe_ids = [(4, dfe_record.id)]
         return dfe_record
 
     def _dfe_create_from_resEvento(self, root, nsu):
         nfe_key = root.chNFe
         dfe_document = self._dfe_get_or_create_document(nfe_key)
-        supplier_cnpj = utils.mask_cnpj("%014d" % root.CNPJ)
 
         dfe_record = (
             self.env["l10n_br_fiscal_dfe.dfe"]
@@ -682,15 +651,10 @@ class ResCompany(models.Model):
             .create(
                 {
                     "access_key": nfe_key,
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "emission_datetime": datetime.strptime(
-                        str(root.dhEvento)[:19], "%Y-%m-%dT%H:%M:%S"
-                    ),
-                    "company_id": self.id,
-                    "event_type_dfe": str(root.tpEvento),
-                    "dfe_nfe_document_type": "dfe_nfe_event",
                     "nsu": nsu,
+                    "company_id": self.id,
+                    "dfe_nfe_document_type": "dfe_nfe_event",
+                    "event_type_dfe": str(root.tpEvento),
                 }
             )
         )
@@ -701,7 +665,6 @@ class ResCompany(models.Model):
     def _dfe_create_from_procEventoNFe(self, root, nsu):
         nfe_key = root.evento.infEvento.chNFe
         dfe_document = self._dfe_get_or_create_document(nfe_key)
-        supplier_cnpj = utils.mask_cnpj("%014d" % root.evento.infEvento.CNPJ)
 
         dfe_record = (
             self.env["l10n_br_fiscal_dfe.dfe"]
@@ -709,14 +672,9 @@ class ResCompany(models.Model):
             .create(
                 {
                     "access_key": nfe_key,
-                    "inclusion_datetime": datetime.now(),
-                    "vat": supplier_cnpj,
-                    "emission_datetime": datetime.strptime(
-                        str(root.evento.infEvento.dhEvento)[:19], "%Y-%m-%dT%H:%M:%S"
-                    ),
+                    "nsu": nsu,
                     "company_id": self.id,
                     "dfe_nfe_document_type": "dfe_nfe_event",
-                    "nsu": nsu,
                 }
             )
         )

--- a/l10n_br_fiscal_dfe/models/res_company.py
+++ b/l10n_br_fiscal_dfe/models/res_company.py
@@ -237,16 +237,28 @@ class ResCompany(models.Model):
             valid = True
 
         if not valid:
-            msg_error = _(
-                "Error validating document distribution: \n\n%(code)s - %(message)s",
-                code=code,
-                message=message,
-            )
-            if raise_message:
-                self._dfe_log(msg_error, log_type="warning", result=result)
-                raise ValidationError(msg_error)
+            if code == CSTAT_NO_DOCS:
+                self._dfe_log(
+                    _(
+                        "No documents found: %(code)s - %(message)s",
+                        code=code,
+                        message=message,
+                    ),
+                    log_type="info",
+                    result=result,
+                )
             else:
-                self._dfe_log(msg_error, log_type="warning", result=result)
+                msg_error = _(
+                    "Error validating document distribution: "
+                    "\n\n%(code)s - %(message)s",
+                    code=code,
+                    message=message,
+                )
+                if raise_message:
+                    self._dfe_log(msg_error, log_type="warning", result=result)
+                    raise ValidationError(msg_error)
+                else:
+                    self._dfe_log(msg_error, log_type="warning", result=result)
         return valid
 
     # ── Distribution actions ────────────────────────────────────────────
@@ -304,6 +316,7 @@ class ResCompany(models.Model):
                 cstat=resp.cStat,
                 motivo=resp.xMotivo,
             ),
+            log_type="success",
             result=result,
         )
         self._dfe_process_distribution(resp)
@@ -367,6 +380,7 @@ class ResCompany(models.Model):
                     ult=last_nsu,
                     mx=max_nsu,
                 ),
+                log_type="success",
                 result=result,
             )
 
@@ -747,6 +761,7 @@ class ResCompany(models.Model):
                 "Document download OK: %(key)s",
                 key=nfe_key,
             ),
+            log_type="success",
             result=result,
         )
         return result.resposta.loteDistDFeInt.docZip[0]

--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -58,7 +58,7 @@ class TestDFe(TransactionCase):
             limit=1,
         )
         self.assertTrue(dfe_record, "procNFe should create a dfe_nfe_complete record")
-        cfop_codes = dfe_record.cfop_ids.mapped("code")
+        cfop_codes = dfe_record.dfe_document_id.cfop_ids.mapped("code")
         self.assertIn("5102", cfop_codes, "CFOP 5102 should be extracted from procNFe")
 
     def test_search_dfe_error_conditions(self):

--- a/l10n_br_fiscal_dfe/tests/test_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_dfe.py
@@ -562,7 +562,7 @@ class TestDFe(TransactionCase):
             [
                 ("message_type", "=", "user_notification"),
                 ("partner_ids", "in", user.partner_id.id),
-                ("subject", "ilike", "DF-e%"),
+                ("body", "ilike", "%DF-e%"),
             ]
         )
         self.assertTrue(
@@ -582,7 +582,7 @@ class TestDFe(TransactionCase):
             [
                 ("message_type", "=", "user_notification"),
                 ("partner_ids", "in", user.partner_id.id),
-                ("subject", "ilike", "DF-e%"),
+                ("body", "ilike", "%DF-e%"),
             ]
         )
         self.assertFalse(
@@ -606,7 +606,7 @@ class TestDFe(TransactionCase):
             [
                 ("message_type", "=", "user_notification"),
                 ("partner_ids", "in", user.partner_id.id),
-                ("subject", "ilike", "DF-e%"),
+                ("body", "ilike", "%DF-e%"),
             ]
         )
         self.assertTrue(
@@ -627,7 +627,7 @@ class TestDFe(TransactionCase):
             [
                 ("message_type", "=", "user_notification"),
                 ("partner_ids", "in", user.partner_id.id),
-                ("subject", "ilike", "DF-e%"),
+                ("body", "ilike", "%DF-e%"),
             ]
         )
         self.assertFalse(
@@ -647,7 +647,7 @@ class TestDFe(TransactionCase):
             [
                 ("message_type", "=", "user_notification"),
                 ("partner_ids", "in", user.partner_id.id),
-                ("subject", "ilike", "DF-e%"),
+                ("body", "ilike", "%DF-e%"),
             ]
         )
         self.assertFalse(

--- a/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
@@ -58,8 +58,6 @@ class TestNFeDFe(TransactionCase):
         self.assertEqual(
             dfe1.access_key, "31201010588201000105550010038421171838422178"
         )
-        self.assertEqual(dfe1.emitter, "ZAP GRAFICA E EDITORA EIRELI")
-        self.assertEqual(dfe1.vat, "10.588.201/0001-05")
         self.assertEqual(dfe1.dfe_nfe_document_type, "dfe_nfe_summary")
         self.assertEqual(dfe1.nsu, "000000000000200")
         self.assertEqual(
@@ -67,6 +65,8 @@ class TestNFeDFe(TransactionCase):
             "31201010588201000105550010038421171838422178 - Resumo da NF-e",
         )
         self.assertEqual(dfe1.dfe_document_id.color_status, "blue")
+        self.assertEqual(dfe1.dfe_document_id.emitter, "ZAP GRAFICA E EDITORA EIRELI")
+        self.assertEqual(dfe1.dfe_document_id.vat, "10.588.201/0001-05")
         self.assertEqual(
             dfe1.dfe_document_id.display_name,
             "31201010588201000105550010038421171838422178",
@@ -80,10 +80,10 @@ class TestNFeDFe(TransactionCase):
         self.assertEqual(
             dfe2.access_key, "35200159594315000157550010000000012062777161"
         )
-        self.assertEqual(dfe2.vat, "59.594.315/0001-57")
         self.assertEqual(dfe2.dfe_nfe_document_type, "dfe_nfe_complete")
-        self.assertEqual(dfe2.emitter, "TESTE - Simples Nacional")
-        self.assertEqual(dfe2.document_amount, 14.0)
+        self.assertEqual(dfe2.dfe_document_id.emitter, "TESTE - Simples Nacional")
+        self.assertEqual(dfe2.dfe_document_id.document_amount, 14.0)
+        self.assertEqual(dfe2.dfe_document_id.vat, "59.594.315/0001-57")
         self.assertEqual(
             dfe2.dfe_document_id.access_key,
             "35200159594315000157550010000000012062777161",

--- a/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
+++ b/l10n_br_fiscal_dfe/tests/test_nfe_dfe.py
@@ -36,12 +36,12 @@ class TestNFeDFe(TransactionCase):
         self.company.dfe_import_documents()
 
         self.assertEqual(len(self.company.dfe_ids), 1)
-        dfe_record = self.company.dfe_ids[0]
-        self.assertTrue(dfe_record.imported_document_id)
-        self.assertEqual(
-            dfe_record.imported_document_id.document_key,
-            "35200159594315000157550010000000012062777161",
+        access_key = "35200159594315000157550010000000012062777161"
+        fiscal_doc = self.env["l10n_br_fiscal.document"].search(
+            [("document_key", "=", access_key)], limit=1
         )
+        self.assertTrue(fiscal_doc, "Fiscal document should be created after import")
+        self.assertEqual(fiscal_doc.document_key, access_key)
         self.assertEqual(_mock_post.call_count, 2)
 
     @mock.patch.object(DefaultTransport, "post")

--- a/l10n_br_fiscal_dfe/views/dfe_distribution_log_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_distribution_log_views.xml
@@ -11,6 +11,8 @@
             <tree
                 create="false"
                 edit="false"
+                decoration-success="log_type == 'success'"
+                decoration-muted="log_type == 'info'"
                 decoration-warning="log_type == 'warning'"
                 decoration-danger="log_type == 'error'"
             >
@@ -69,6 +71,11 @@
             <search>
                 <field name="message" />
                 <field name="company_id" groups="base.group_multi_company" />
+                <filter
+                    name="success"
+                    string="Success"
+                    domain="[('log_type', '=', 'success')]"
+                />
                 <filter
                     name="info"
                     string="Info"

--- a/l10n_br_fiscal_dfe/views/dfe_document_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_document_views.xml
@@ -86,6 +86,7 @@
                             <field name="dfe_ids">
                                 <tree>
                                     <field name="dfe_nfe_document_type" string="DF-e" />
+                                    <field name="event_type_dfe_label" string="Event" />
                                     <field name="nsu" />
                                     <button
                                         string="XML"

--- a/l10n_br_fiscal_dfe/views/dfe_document_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_document_views.xml
@@ -232,7 +232,7 @@
     </record>
 
     <record model="ir.actions.act_window" id="dfe_document_action">
-        <field name="name">Received NF-es</field>
+        <field name="name">Third-party NF-e</field>
         <field name="res_model">l10n_br_fiscal_dfe.document</field>
         <field name="view_mode">tree,form</field>
         <field name="domain">[('is_own_document', '=', False)]</field>

--- a/l10n_br_fiscal_dfe/views/dfe_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_views.xml
@@ -16,22 +16,15 @@
                 <separator string="Document Info" />
                 <group>
                     <group>
-                        <field name="document_number" readonly="1" />
                         <field name="nsu" readonly="1" />
-                        <field name="vat" readonly="1" />
-                        <field name="ie" readonly="1" />
-                        <field name="document_amount" widget="monetary" readonly="1" />
-                        <field name="document_state" readonly="1" />
-                        <field name="cfop_ids" readonly="1" widget="many2many_tags" />
+                        <field name="dfe_nfe_document_type" readonly="1" />
+                        <field name="event_type_dfe_label" readonly="1" />
+                        <field name="operation_type" readonly="1" />
                     </group>
                     <group>
                         <field name="company_id" readonly="1" />
                         <field name="imported_document_id" readonly="1" />
-                        <field name="operation_type" readonly="1" />
-                        <field name="inclusion_datetime" readonly="1" />
-                        <field name="emission_datetime" readonly="1" />
                         <field name="attachment_id" readonly="1" />
-                        <field name="display_name" readonly="1" />
                     </group>
                     <label for="xml_pretty" string="XML Attachment" />
                     <field
@@ -60,8 +53,6 @@
                     type="object"
                     icon="fa-download"
                 />
-                <field name="emission_datetime" widget="datetime" string="Emission" />
-                <field name="inclusion_datetime" widget="datetime" string="Inclusion" />
             </tree>
         </field>
     </record>

--- a/l10n_br_fiscal_dfe/views/dfe_views.xml
+++ b/l10n_br_fiscal_dfe/views/dfe_views.xml
@@ -23,7 +23,7 @@
                     </group>
                     <group>
                         <field name="company_id" readonly="1" />
-                        <field name="imported_document_id" readonly="1" />
+                        <field name="dfe_document_id" readonly="1" />
                         <field name="attachment_id" readonly="1" />
                     </group>
                     <label for="xml_pretty" string="XML Attachment" />

--- a/l10n_br_fiscal_dfe/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal_dfe/views/l10n_br_fiscal_menu.xml
@@ -6,13 +6,6 @@
 -->
 <odoo>
     <menuitem
-        id="dfe_distribution_menu"
-        name="DF-e Distribution"
-        parent="l10n_br_nfe.nfe_sub_menu"
-        groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager"
-        sequence="15"
-    />
-    <menuitem
         id="dfe_queries_menu"
         name="DF-e Queries"
         parent="l10n_br_fiscal.fiscal_menu"
@@ -25,19 +18,5 @@
         name="Third-party NF-e"
         parent="dfe_queries_menu"
         sequence="10"
-    />
-    <menuitem
-        id="dfe_record_menu"
-        action="dfe_action"
-        name="DF-e Records"
-        parent="dfe_distribution_menu"
-        sequence="20"
-    />
-    <menuitem
-        id="dfe_distribution_log_menu"
-        action="dfe_distribution_log_action"
-        name="Distribution Log"
-        parent="dfe_distribution_menu"
-        sequence="30"
     />
 </odoo>

--- a/l10n_br_fiscal_dfe/views/l10n_br_fiscal_menu.xml
+++ b/l10n_br_fiscal_dfe/views/l10n_br_fiscal_menu.xml
@@ -13,10 +13,17 @@
         sequence="15"
     />
     <menuitem
+        id="dfe_queries_menu"
+        name="DF-e Queries"
+        parent="l10n_br_fiscal.fiscal_menu"
+        groups="l10n_br_fiscal.group_user,l10n_br_fiscal.group_manager"
+        sequence="15"
+    />
+    <menuitem
         id="dfe_document_menu"
         action="dfe_document_action"
-        name="Received NF-es"
-        parent="dfe_distribution_menu"
+        name="Third-party NF-e"
+        parent="dfe_queries_menu"
         sequence="10"
     />
     <menuitem

--- a/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
+++ b/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
@@ -75,6 +75,6 @@ class DFeSpecificSearchWizard(models.TransientModel):
                 "title": _("Success"),
                 "message": _("Specific search triggered successfully"),
                 "type": "success",
-                "next": {"type": "ir.actions.act_window_close"},
+                "next": {"type": "ir.actions.client", "tag": "reload"},
             },
         }

--- a/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
+++ b/l10n_br_fiscal_dfe/wizards/specific_search_wizard.py
@@ -60,6 +60,31 @@ class DFeSpecificSearchWizard(models.TransientModel):
         except ValueError as exc:
             raise UserError(str(exc)) from exc
 
+    def _validate_nsu(self, nsu):
+        """Validate NSU value and check if it already exists."""
+        if not nsu or not nsu.strip():
+            raise UserError(_("Please enter an NSU."))
+        digits_only = re.sub(r"[^0-9]", "", nsu)
+        if not digits_only:
+            raise UserError(_("NSU must contain only numbers."))
+        if all(char == "0" for char in digits_only):
+            raise UserError(_("NSU cannot be zero."))
+        existing = self.env["l10n_br_fiscal_dfe.dfe"].search(
+            [
+                ("nsu", "=", digits_only.zfill(15)),
+                ("company_id", "=", self.company_id.id),
+            ],
+            limit=1,
+        )
+        if existing:
+            raise UserError(
+                _(
+                    "NSU %(nsu)s already exists in the database (DF-e #%(dfe_id)s).",
+                    nsu=nsu,
+                    dfe_id=existing.id,
+                )
+            )
+
     def action_confirm_search(self):
         self.ensure_one()
         if self.search_type == "access_key":
@@ -67,6 +92,7 @@ class DFeSpecificSearchWizard(models.TransientModel):
             self._validate_access_key(access_key)
             self.company_id._dfe_search_specific_document(access_key=access_key)
         else:
+            self._validate_nsu(self.nsu)
             self.company_id._dfe_search_specific_document(nsu=self.nsu)
         return {
             "type": "ir.actions.client",


### PR DESCRIPTION
## Resumo

Rebase da PR #48 (`v10`) sobre a `16.0` atualizada. Agora toca **apenas** o módulo `l10n_br_fiscal_dfe` — sem diff fantasma do `l10n_br_account_payment_brcobranca`.

### Commits (13)

**Notificações e UI:**
- Fix notification delivery e linguagem por usuário
- Testes de notificação filtrados por body
- Menu top-level DF-e Queries + remoção do submenu Distribution
- Log de distribuição com tipos e cores melhorados

**Traduções:**
- pt_BR atualizado
- Traduções dos novos tipos de log

**Refatoração do modelo dfe:**
- Simplificar modelo dfe: mover metadados para dfe_document (stored)
- Remover `imported_document_id` do dfe
- Testes atualizados para a nova estrutura

**Pesquisa específica:**
- Reload da página após pesquisa específica
- Validação de NSU no wizard

**Fixes:**
- `event_type_dfe` no `procEventoNFe` + extração de metadados da chave de acesso

### Diferenças em relação à v10
- Rebase limpo na `16.0` (1 commit skipped — já estava na base)
- Sem alterações em outros módulos