### PR TITLE
[16.0][IMP] Usar campo related para ind_final na linha do documento fiscal

### DIFF
--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -82,6 +82,14 @@ class FiscalDocument(models.Model):
         readonly=False,
     )
 
+    @api.depends("proxy_partner_id")
+    def _compute_ind_final(self):
+        """Extend dependency: the mixin depends on partner_id, but in
+        l10n_br_account partner_id is a related to proxy_partner_id.
+        The ORM does not always chain the recompute through the related,
+        so we add proxy_partner_id as an explicit trigger."""
+        return super()._compute_ind_final()
+
     @api.onchange("company_id")
     def _inverse_company_id(self):
         for doc in self:

--- a/l10n_br_account/tests/test_move_edition.py
+++ b/l10n_br_account/tests/test_move_edition.py
@@ -572,3 +572,102 @@ class TestMoveEdition(TransactionCase):
             move_after_total_update.fiscal_amount_total, 2776.48, places=2
         )
         self.assertAlmostEqual(move_after_total_update.amount_total, 2776.48, places=2)
+
+    def _setup_fiscal_user(self):
+        """Grant fiscal groups needed for invoice tests with fiscal documents."""
+        self.user.groups_id += self.env.ref("l10n_br_fiscal.group_user")
+        nfe_user_group = self.env.ref(
+            "l10n_br_nfe.group_user", raise_if_not_found=False
+        )
+        if nfe_user_group:
+            self.user.groups_id += nfe_user_group
+
+    def _create_fiscal_invoice_form(self, partner):
+        """Create a fiscal invoice Form pre-filled with the given partner."""
+        move_form = Form(
+            self.env["account.move"].with_context(
+                default_move_type="out_invoice",
+            )
+        )
+        move_form.partner_id = partner
+        move_form.document_type_id = self.env.ref("l10n_br_fiscal.document_55")
+        move_form.document_serie_id = self.env.ref(
+            "l10n_br_fiscal.empresa_lc_document_55_serie_1"
+        )
+        move_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        return move_form
+
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final directly on a saved invoice must propagate
+        to the fiscal document lines."""
+        self._setup_fiscal_user()
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+
+        move_form = self._create_fiscal_invoice_form(partner)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "1")
+        self.assertEqual(fiscal_line.ind_final, "1")
+
+        # Manually change ind_final on the invoice
+        move.write({"ind_final": "0"})
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved invoice must propagate ind_final
+        to the fiscal document lines when the new partner differs."""
+        self._setup_fiscal_user()
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        move_form = self._create_fiscal_invoice_form(partner_final)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "1")
+        self.assertEqual(fiscal_line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        move.write({"partner_id": partner_not_final.id})
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on an unsaved invoice form must propagate
+        ind_final to existing lines both in the form and after saving."""
+        self._setup_fiscal_user()
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        move_form = self._create_fiscal_invoice_form(partner_final)
+        with move_form.invoice_line_ids.new() as line_form:
+            line_form.product_id = self.product_id
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        self.assertEqual(move_form.ind_final, "1")
+
+        # Change partner without saving
+        move_form.partner_id = partner_not_final
+        self.assertEqual(move_form.ind_final, "0")
+
+        # Verify after saving
+        move = move_form.save()
+        fiscal_line = move.fiscal_line_ids[0]
+        self.assertEqual(move.ind_final, "0")
+        self.assertEqual(fiscal_line.ind_final, "0")

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -95,6 +95,13 @@ class DocumentLine(models.Model):
         related="document_id.edoc_purpose",
     )
 
+    ind_final = fields.Selection(
+        related="document_id.ind_final",
+        store=True,
+        precompute=True,
+        readonly=True,
+    )
+
     additional_data = fields.Text()
 
     @api.depends("product_id")

--- a/l10n_br_fiscal/models/document_line_mixin.py
+++ b/l10n_br_fiscal/models/document_line_mixin.py
@@ -971,17 +971,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     ind_final = fields.Selection(
         selection=FINAL_CUSTOMER,
         string="Consumidor final",
-        compute="_compute_ind_final",
-        store=True,
-        precompute=True,
-        readonly=False,
     )
-
-    def _compute_ind_final(self):
-        for line in self:
-            doc = line._get_document()
-            if line.ind_final != doc.ind_final:
-                line.ind_final = doc.ind_final
 
     partner_company_type = fields.Selection(related="partner_id.company_type")
 

--- a/l10n_br_fiscal/tests/test_document_edition.py
+++ b/l10n_br_fiscal/tests/test_document_edition.py
@@ -346,6 +346,102 @@ class TestDocumentEdition(TransactionCase):
         # fiscal_amount_untaxed = (2000+40+20+8) + (500+10+5+2) = 2585
         self.assertAlmostEqual(doc.fiscal_amount_untaxed, 2585.0)
 
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved document must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the document
+        doc.write({"ind_final": "0"})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved document must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        doc.write({"partner_id": partner_not_final.id})
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on a form before saving must propagate
+        ind_final to lines when saved."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        doc_form = Form(
+            self.env["l10n_br_fiscal.document"].with_context(
+                default_fiscal_operation_type="out",
+            )
+        )
+        doc_form.company_id = self.company
+        doc_form.partner_id = partner_final
+        doc_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+
+        product = self.env.ref("product.product_product_6")
+        with doc_form.fiscal_line_ids.new() as line_form:
+            line_form.product_id = product
+            line_form.price_unit = 100.0
+            line_form.quantity = 1.0
+
+        self.assertEqual(doc_form.ind_final, "1")
+
+        # Change partner before saving
+        doc_form.partner_id = partner_not_final
+        self.assertEqual(doc_form.ind_final, "0")
+
+        doc = doc_form.save()
+        line = doc.fiscal_line_ids[0]
+        self.assertEqual(doc.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
     def test_difal_calculation(self):
         partner = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
         partner.ind_ie_dest = "9"

--- a/l10n_br_sale/tests/__init__.py
+++ b/l10n_br_sale/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_l10n_br_sale_discount
 from . import test_l10n_br_sale_sn
 from . import test_l10n_br_sale_pricelist
 from . import test_sale_order_report
+from . import test_sale_order_ind_final

--- a/l10n_br_sale/tests/test_sale_order_ind_final.py
+++ b/l10n_br_sale/tests/test_sale_order_ind_final.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Engenere
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import TransactionCase
+from odoo.tests.common import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderIndFinal(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.company = cls.env.ref("l10n_br_base.empresa_lucro_presumido")
+        cls.user = cls.env.user
+        cls.user.company_ids |= cls.company
+        cls.user.company_id = cls.company.id
+        cls.product = cls.env.ref("product.product_product_6")
+
+    def _create_sale_order_form(self, partner):
+        """Create a sale order Form pre-filled with the given partner."""
+        so_form = Form(self.env["sale.order"])
+        so_form.company_id = self.company
+        so_form.partner_id = partner
+        so_form.fiscal_operation_id = self.env.ref("l10n_br_fiscal.fo_venda")
+        return so_form
+
+    def test_ind_final_propagation_on_manual_change(self):
+        """Changing ind_final on a saved sale order must propagate to lines."""
+        partner = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner.ind_final = "1"
+
+        so_form = self._create_sale_order_form(partner)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Manually change ind_final on the order
+        so.write({"ind_final": "0"})
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_partner_change(self):
+        """Changing partner_id on a saved sale order must propagate ind_final
+        to lines when the new partner has a different ind_final."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        so_form = self._create_sale_order_form(partner_final)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "1")
+        self.assertEqual(line.ind_final, "1")
+
+        # Change to a partner with ind_final="0"
+        so.write({"partner_id": partner_not_final.id})
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")
+
+    def test_ind_final_propagation_on_form_partner_change(self):
+        """Changing partner_id on a form before saving must propagate
+        ind_final to lines when saved."""
+        partner_final = self.env.ref("l10n_br_base.res_partner_cliente1_sp")
+        partner_final.ind_final = "1"
+        partner_not_final = self.env.ref("l10n_br_base.res_partner_cliente5_pe")
+        partner_not_final.ind_final = "0"
+
+        so_form = self._create_sale_order_form(partner_final)
+        with so_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 1.0
+
+        self.assertEqual(so_form.ind_final, "1")
+
+        # Change partner before saving
+        so_form.partner_id = partner_not_final
+        self.assertEqual(so_form.ind_final, "0")
+
+        so = so_form.save()
+        line = so.order_line.filtered(lambda line: not line.display_type)[0]
+        self.assertEqual(so.ind_final, "0")
+        self.assertEqual(line.ind_final, "0")


### PR DESCRIPTION
## Resumo

- Substitui o campo `ind_final` computado no modelo `l10n_br_fiscal.document.line` por um campo `related` apontando para `document_id.ind_final`, com `store=True`, `precompute=True` e `readonly=True`
- Adiciona dependência explícita em `proxy_partner_id` no `_compute_ind_final` do `l10n_br_account` para garantir recomputo correto quando o parceiro muda via proxy fields
- Adiciona 9 testes cobrindo propagação de `ind_final`: mudança manual, troca de parceiro via `write()`, e troca de parceiro em formulário não salvo — nos módulos `l10n_br_fiscal`, `l10n_br_account` e `l10n_br_sale`

## Contexto

O campo `ind_final` (consumidor final) no `document.line.mixin` usa `_compute_ind_final` com `_get_document()` para buscar o valor do documento pai. Como o mixin não conhece o nome do campo do documento pai, esta abordagem polimórfica era necessária no nível do mixin.

Entretanto, no modelo concreto `l10n_br_fiscal.document.line`, o campo do documento pai é `document_id`, então podemos usar `related="document_id.ind_final"` diretamente, delegando a sincronização para o ORM.

### Detalhe técnico: `readonly=True`

O campo `related` **deve** ser `readonly=True` para evitar que o ORM chame `_inverse_related` durante o `create()` de linhas. Sem isso, durante a criação via `_inherits` (`account.move` → `fiscal.document`), o ORM:

1. Insere a linha com o valor correto de `ind_final`
2. Chama `_inverse_related` que escreve o valor cacheado (possivelmente defasado) de volta no documento
3. O documento recebe o valor errado, sobrescrevendo o valor correto

Com `readonly=True`, a inversão não é registrada e o fluxo funciona corretamente.

## Plano de testes

- [x] 3 testes `l10n_br_fiscal`: propagação manual, troca de parceiro, troca de parceiro no formulário
- [x] 3 testes `l10n_br_account`: mesmos cenários para `account.move`
- [x] 3 testes `l10n_br_sale`: mesmos cenários para `sale.order`
- [x] Testes existentes dos 3 módulos continuam passando