### PR TITLE
[16.0][FIX] l10n_br_sale: recalcula impostos com base na quantidade faturada

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -193,10 +193,21 @@ class SaleOrderLine(models.Model):
     def _prepare_invoice_line(self, **optional_values):
         self.ensure_one()
         result = {}
+        super_result = super()._prepare_invoice_line(**optional_values)
         if not self.display_type and self.fiscal_operation_id:
             result = self._prepare_br_fiscal_dict()
-            result.pop("fiscal_quantity", None)
-        result.update(super()._prepare_invoice_line(**optional_values))
+            invoice_qty = super_result["quantity"]
+            if invoice_qty != result["quantity"]:
+                # Tax fields must be recomputed for the invoiced quantity.
+                virtual = self.env["l10n_br_fiscal.document.line"].new(result)
+                virtual.quantity = invoice_qty
+                result = {
+                    fname: virtual._fields[fname].convert_to_write(
+                        virtual[fname], virtual
+                    )
+                    for fname in result
+                }
+        result.update(super_result)
         return result
 
     @api.depends(

--- a/l10n_br_sale/tests/test_l10n_br_sale_lp.py
+++ b/l10n_br_sale/tests/test_l10n_br_sale_lp.py
@@ -12,7 +12,7 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
     so_product_service_ref = "l10n_br_sale.lc_so_product_service"
 
     def test_partial_invoice_fiscal_quantity(self):
-        """Test fiscal_quantity on partial invoices with delivery policy."""
+        """Test fiscal fields on partial invoices with delivery policy."""
         self._change_user_company(self.company)
         self._run_sale_order_onchanges(self.so_products)
         so_lines = self.so_products.order_line.filtered(
@@ -25,11 +25,9 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
 
         self.so_products.action_confirm()
 
-        # First delivery: half
         for line in so_lines:
             line.qty_delivered = line.product_uom_qty / 2.0
 
-        # First invoice
         self.so_products._create_invoices()
         first_invoice = self.so_products.invoice_ids[0]
         inv_lines = first_invoice.invoice_line_ids.filtered(
@@ -43,14 +41,13 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
             expected_fiscal_qty = expected_qty * uot_factor
             self.assertAlmostEqual(inv_line.quantity, expected_qty, 2)
             self.assertAlmostEqual(inv_line.fiscal_quantity, expected_fiscal_qty, 2)
+        self._assert_tax_fields_match_recompute(inv_lines)
 
         first_invoice.action_post()
 
-        # Second delivery: remaining half
         for line in so_lines:
             line.qty_delivered = line.product_uom_qty
 
-        # Second invoice
         self.so_products._create_invoices()
         second_invoice = self.so_products.invoice_ids.filtered(
             lambda inv: inv.id != first_invoice.id
@@ -66,3 +63,31 @@ class TestL10nBrSale(L10nBrSaleBaseTest, TransactionCase):
             expected_fiscal_qty = expected_qty * uot_factor
             self.assertAlmostEqual(inv_line.quantity, expected_qty, 2)
             self.assertAlmostEqual(inv_line.fiscal_quantity, expected_fiscal_qty, 2)
+        self._assert_tax_fields_match_recompute(inv_lines)
+
+    def _assert_tax_fields_match_recompute(self, inv_lines):
+        """Assert tax fields match a fresh recompute."""
+        tax_fields = (
+            "icms_base",
+            "icms_value",
+            "icmssn_base",
+            "icmssn_credit_value",
+            "ipi_base",
+            "ipi_value",
+            "pis_base",
+            "pis_value",
+            "cofins_base",
+            "cofins_value",
+        )
+        for inv_line in inv_lines:
+            fdl = inv_line.fiscal_document_line_id
+            before = {f: fdl[f] for f in tax_fields}
+            fdl._compute_tax_fields()
+            for f, stored in before.items():
+                self.assertAlmostEqual(
+                    fdl[f],
+                    stored,
+                    2,
+                    f"{f} differs after recompute: stored={stored}, "
+                    f"recomputed={fdl[f]}",
+                )


### PR DESCRIPTION
## Problema

Quando a quantidade faturada difere da pedida (seja por faturamento parcial, seja porque o produto é faturado pela quantidade entregue), os impostos da fatura saem calculados para a quantidade do pedido, não a da fatura.

Ao gerar a fatura, os campos calculados de impostos são copiados literalmente da linha do pedido para a linha da fatura. Em Odoo 16 esses campos são calculados automaticamente, mas quando o ORM recebe os valores prontos na criação ele aceita sem refazer a conta — mesmo que a quantidade tenha mudado.

A #4371 mitigou parcialmente, removendo apenas `fiscal_quantity` do que é copiado; os demais campos continuam congelados.

Em v14 havia uma proteção em `account.move.line.create()` que reescrevia esses valores e forçava o recálculo na criação. Foi removida no commit `2ed9a96e7` (01/04/2025), quando `fiscal_quantity`/`fiscal_price` viraram campos calculados.

## Correção

O que muda entre o pedido e a fatura é a quantidade faturada. Simulamos essa mudança num registro virtual da linha fiscal: ao mudar a quantidade, o ORM percebe a alteração e recalcula os impostos naturalmente — é a mesma mecânica (`Model.new()`) usada pelo sistema de onchange.

Os valores recalculados são lidos do cache campo a campo, em vez de `read()`, para evitar a verificação de permissão sobre o registro transitório.

## Teste

O teste existente (`test_partial_invoice_fiscal_quantity`, de #4371) foi estendido: captura os impostos da linha da fatura, força o recálculo, e verifica que os valores não mudam. Sem o fix, falha. Com o fix, os 24 testes do módulo passam.

## Impacto

Descoberto em produção: clientes do Simples Nacional recebiam NFs com crédito de ICMS calculado para a quantidade pedida em vez da efetivamente faturada.