### PR TITLE
[16.0][FIX] l10n_br_account: limpa conciliações ao cancelar documento fiscal

### DIFF
--- a/l10n_br_account/models/document.py
+++ b/l10n_br_account/models/document.py
@@ -271,12 +271,28 @@ class FiscalDocument(models.Model):
                 move.message_post(**kwargs)
         return res
 
-    def cancel_move_ids(self):
+    def _check_cancel_move_ids_allowed(self):
+        """Fail fast on closed period before the irreversible SEFAZ call."""
         for record in self:
-            if record.move_ids:
-                self.move_ids.button_cancel()
+            moves = record.move_ids.filtered(lambda m: m.state == "posted")
+            if moves:
+                moves._check_fiscalyear_lock_date()
+                moves.line_ids._check_tax_lock_date()
+
+    def cancel_move_ids(self):
+        # Replicate the core button_draft cleanup (analytic + reconcile)
+        # without invoking the override that blocks documents already
+        # cancelled at SEFAZ.
+        for record in self:
+            moves = record.move_ids
+            if not moves:
+                continue
+            moves.mapped("line_ids.analytic_line_ids").unlink()
+            moves.mapped("line_ids").remove_move_reconcile()
+            moves.button_cancel()
 
     def _document_cancel(self, justificative):
+        self._check_cancel_move_ids_allowed()
         result = super()._document_cancel(justificative)
         msg = f"Cancelamento: {justificative}"
         self.cancel_move_ids()

--- a/l10n_br_account/tests/__init__.py
+++ b/l10n_br_account/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_invoice_refund
 from . import test_multi_localizations_invoice
 from . import test_payment_status
 from . import test_move_workflow
+from . import test_cancel_move_ids

--- a/l10n_br_account/tests/test_cancel_move_ids.py
+++ b/l10n_br_account/tests/test_cancel_move_ids.py
@@ -1,0 +1,123 @@
+# Copyright 2026 - Engenere (<https://engenere.one>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests.common import Form, tagged
+
+from .common import AccountMoveBRCommon
+
+
+@tagged("post_install", "-at_install")
+class TestCancelMoveIds(AccountMoveBRCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.configure_normal_company_taxes()
+        cls.invoice = cls.init_invoice(
+            "out_invoice",
+            products=[cls.product_a],
+            document_type=cls.env.ref("l10n_br_fiscal.document_55"),
+            document_serie_id=cls.empresa_lc_document_55_serie_1,
+            fiscal_operation=cls.env.ref("l10n_br_fiscal.fo_venda"),
+            fiscal_operation_lines=[cls.env.ref("l10n_br_fiscal.fo_venda_venda")],
+        )
+
+    def _register_payment(self, invoice, amount):
+        bank_journal = self.company_data["default_journal_bank"]
+        with Form(
+            self.env["account.payment.register"].with_context(
+                active_model="account.move", active_ids=invoice.ids
+            )
+        ) as wiz_form:
+            wiz_form.journal_id = bank_journal
+            wiz_form.payment_date = fields.Date.today()
+            wiz_form.amount = amount
+        wiz = wiz_form.save()
+        return wiz._create_payments()
+
+    def test_cancel_move_ids_clears_reconciliation(self):
+        self.invoice.action_post()
+        self.assertEqual(self.invoice.payment_state, "not_paid")
+        residual_before_payment = self.invoice.amount_residual
+
+        payment = self._register_payment(self.invoice, residual_before_payment)
+        self.assertEqual(self.invoice.payment_state, "paid")
+        self.assertEqual(self.invoice.amount_residual, 0.0)
+
+        def _receivable(line):
+            return line.account_id.account_type == "asset_receivable"
+
+        inv_recv = self.invoice.line_ids.filtered(_receivable)
+        pay_recv = payment.line_ids.filtered(_receivable)
+        self.assertTrue(pay_recv.reconciled)
+        partials = inv_recv.matched_credit_ids | inv_recv.matched_debit_ids
+        self.assertTrue(partials)
+
+        self.invoice.fiscal_document_id.cancel_move_ids()
+
+        self.assertEqual(self.invoice.state, "cancel")
+        self.assertFalse(pay_recv.reconciled)
+        self.assertFalse(inv_recv.reconciled)
+        self.assertFalse(payment.is_reconciled)
+        self.assertFalse(inv_recv.matched_credit_ids | inv_recv.matched_debit_ids)
+        self.assertFalse(partials.exists())
+
+    def test_cancel_move_ids_clears_analytic_lines(self):
+        """Regression for OCA/l10n-brazil#3217."""
+        plan = self.env["account.analytic.plan"].create({"name": "Test Plan"})
+        analytic_account = self.env["account.analytic.account"].create(
+            {"name": "Test Analytic Account", "plan_id": plan.id}
+        )
+        product_line = self.invoice.invoice_line_ids[:1]
+        product_line.analytic_distribution = {str(analytic_account.id): 100.0}
+        self.invoice.action_post()
+
+        analytic_lines = self.env["account.analytic.line"].search(
+            [("move_line_id", "in", self.invoice.line_ids.ids)]
+        )
+        self.assertTrue(analytic_lines)
+
+        self.invoice.fiscal_document_id.cancel_move_ids()
+
+        self.assertFalse(analytic_lines.exists())
+
+    def test_cancel_move_ids_idempotent(self):
+        self.invoice.action_post()
+        self.invoice.fiscal_document_id.cancel_move_ids()
+        self.assertEqual(self.invoice.state, "cancel")
+        self.invoice.fiscal_document_id.cancel_move_ids()
+        self.assertEqual(self.invoice.state, "cancel")
+
+    def test_document_cancel_blocks_on_lock_date_before_sefaz(self):
+        # Calls the full _document_cancel entry point so the test fails if
+        # the preflight ever gets dropped from the chain.
+        self.invoice.action_post()
+        self.invoice.company_id.fiscalyear_lock_date = self.invoice.invoice_date
+        document = self.invoice.fiscal_document_id
+        state_edoc_before = document.state_edoc
+
+        with self.assertRaises(UserError):
+            document._document_cancel("Test cancellation with more than 15 chars")
+
+        self.assertEqual(document.state_edoc, state_edoc_before)
+        self.assertEqual(self.invoice.state, "posted")
+
+    def test_cancel_move_ids_preserves_state_edoc(self):
+        # Guards against naively reusing button_draft, which would trigger
+        # action_document_back2draft and regress state_edoc.
+        self.invoice.action_post()
+        document = self.invoice.fiscal_document_id
+        document.flush_recordset()
+        self.env.cr.execute(
+            "UPDATE l10n_br_fiscal_document SET state_edoc = 'cancelada' "
+            "WHERE id = %s",
+            (document.id,),
+        )
+        document.invalidate_recordset(["state_edoc"])
+        self.assertEqual(document.state_edoc, "cancelada")
+
+        document.cancel_move_ids()
+
+        self.assertEqual(self.invoice.state, "cancel")
+        self.assertEqual(document.state_edoc, "cancelada")


### PR DESCRIPTION
## Resumo

Ao cancelar um documento fiscal (cancelamento manual na SEFAZ ou denegação), o `account.move` ia direto pra `cancel` via `button_cancel`, pulando a limpeza que o `button_draft` core faz: `remove_move_reconcile` e `analytic_line_ids.unlink`. Pagamentos conciliados contra a fatura cancelada ficavam marcados como `reconciled=True` contra um move já em `cancel` e não apareciam no widget de pendentes da fatura substituta — ficavam órfãos.

## Como reproduzir

1. Emitir NF-e (fatura A) e transmitir à SEFAZ.
2. Registrar pagamento e conciliar contra a fatura A.
3. Cancelar a NF-e na SEFAZ (motivo: alterar dados).
4. Emitir nova NF-e (fatura B) pelo mesmo pedido.
5. Tentar vincular o pagamento à fatura B.

**Antes do fix:** o pagamento não aparece no widget de pendentes da fatura B. A linha de recebível do pagamento continua `reconciled=True` contra a fatura A cancelada.

**Após o fix:** ao cancelar a NF-e via SEFAZ, a conciliação é desfeita automaticamente; o pagamento volta a aparecer no widget da fatura B.

## Causa raiz

`l10n_br_account.cancel_move_ids` chamava `button_cancel()` direto no `account.move`. No core, o caminho oficial para mover uma fatura paga para `cancel` passa por `button_draft` (que internamente chama `line_ids.remove_move_reconcile()` e apaga `analytic_line_ids`), depois `button_cancel`. O atalho do `cancel_move_ids` pulava esse passo.

Chamar `button_draft()` direto também não funciona aqui: o override em `l10n_br_account.account_move` bloqueia com `UserError` documentos que já estão `state_edoc == cancelada` e tenta voltar o documento fiscal para `em_digitacao` via `action_document_back2draft()` — exatamente o estado em que estamos pós-SEFAZ.

## Solução

`cancel_move_ids` passa a replicar cirurgicamente o miolo do `account.move.button_draft` core (`analytic_line_ids.unlink` + `remove_move_reconcile` + `button_cancel`), sem invocar o método sobrescrito que travaria. A mesma correção cobre o caminho de denegação, que também passa por `cancel_move_ids`.

`_document_cancel` ganha um preflight (`_check_cancel_move_ids_allowed`) que executa `_check_fiscalyear_lock_date` e `_check_tax_lock_date` nos moves antes do `super()`, ou seja, antes do webservice SEFAZ. Sem isso, se o período fiscal estivesse fechado, a NF-e seria cancelada na SEFAZ mas o `account.move` continuaria `posted` no ERP — divergência difícil de reverter. Esse preflight protege o fluxo de cancelamento iniciado pelo usuário; o caminho de denegação não é coberto porque a decisão da SEFAZ é fato consumado e não há como rejeitar localmente.

## Testes

5 cenários novos em `l10n_br_account/tests/test_cancel_move_ids.py`:

- `test_cancel_move_ids_clears_reconciliation` — fatura paga: após `cancel_move_ids` a `account.partial.reconcile` é removida e ambas as AMLs voltam a `reconciled=False`.
- `test_cancel_move_ids_clears_analytic_lines` — cobre regressão de OCA/l10n-brazil#3217 (linhas analíticas não removidas ao cancelar via documento fiscal).
- `test_cancel_move_ids_idempotent` — chamar duas vezes não explode.
- `test_document_cancel_blocks_on_lock_date_before_sefaz` — `_document_cancel` levanta `UserError` antes do `super()`/SEFAZ quando o período fiscal está fechado; `state_edoc` e `account.move.state` ficam intactos.
- `test_cancel_move_ids_preserves_state_edoc` — `state_edoc` não regride para `em_digitacao` após o cleanup local (guarda contra a regressão de chamar `button_draft` direto).

## Issues relacionadas

- Fecha funcionalmente OCA/l10n-brazil#3217.