### PR TITLE
[16.0][FIX] l10n_br_nfe: export vItem and vNFTot tags (NT 2025.002)

### DIFF
--- a/l10n_br_nfe/models/document.py
+++ b/l10n_br_nfe/models/document.py
@@ -810,6 +810,14 @@ class NFe(spec_models.StackedModel):
     # Framework Spec model's methods
     ################################
 
+    def _nfe_export_ibscbs_totals(self):
+        """Return True when the document has IBS/CBS values to export"""
+        self.ensure_one()
+        return bool(
+            sum(self.fiscal_line_ids.mapped("ibs_value"))
+            or sum(self.fiscal_line_ids.mapped("cbs_value"))
+        )
+
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         if xsd_field == "nfe40_tpAmb":
             self.env.context = dict(self.env.context)
@@ -818,11 +826,21 @@ class NFe(spec_models.StackedModel):
                 xsd_field, class_obj, member_spec, export_value
             )
 
-        if xsd_field == "nfe40_IBSCBSTot":
-            total_ibs = sum(self.fiscal_line_ids.mapped("ibs_value"))
-            total_cbs = sum(self.fiscal_line_ids.mapped("cbs_value"))
+        if xsd_field == "nfe40_vNFTot":
+            # NT 2025.002 (rule W60): total of the NF-e considering the
+            # IBS/CBS/IS taxes. This mirrors fiscal_amount_total, which
+            # already honors each tax group's "tax_include" flag: taxes
+            # flagged as included in the price do not add to the total,
+            # taxes flagged as "outside" do. In the 2026 transition the
+            # IBS/CBS/IS groups are set as included, so vNFTot equals vNF;
+            # switching those groups to "outside" makes them compose the
+            # total automatically, with no code change.
+            if not self._nfe_export_ibscbs_totals():
+                return False
+            return f"{self.fiscal_amount_total:.2f}"
 
-            if not total_ibs and not total_cbs:
+        if xsd_field == "nfe40_IBSCBSTot":
+            if not self._nfe_export_ibscbs_totals():
                 return False
 
             # Build gIBSUF

--- a/l10n_br_nfe/models/document_line.py
+++ b/l10n_br_nfe/models/document_line.py
@@ -222,6 +222,19 @@ class NFeLine(spec_models.StackedModel):
 
     def _export_field(self, xsd_field, class_obj, member_spec, export_value=None):
         """Override to handle IBSCBS field export"""
+        if xsd_field == "nfe40_vItem":
+            # NT 2025.002 (rules VB01/W60): vItem must be present in every
+            # det when the document exports the IBS/CBS totals, and the sum
+            # of all vItem must match vNFTot. This mirrors the line's
+            # fiscal_amount_total, which already honors each tax group's
+            # "tax_include" flag; in the 2026 transition IBS/CBS/IS are
+            # included in the price, so vItem is the line share of the
+            # current vNF (switching the groups to "outside" makes them
+            # compose vItem automatically, keeping sum(vItem) == vNFTot).
+            if not self.document_id._nfe_export_ibscbs_totals():
+                return False
+            return f"{self.fiscal_amount_total:.2f}"
+
         if xsd_field == "nfe40_IBSCBS":
             if not self.ibs_value and not self.cbs_value:
                 return False

--- a/l10n_br_nfe/tests/test_nfe_ibscbs.py
+++ b/l10n_br_nfe/tests/test_nfe_ibscbs.py
@@ -1,6 +1,8 @@
 # Copyright 2025
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from decimal import Decimal
+
 from odoo.tests import TransactionCase, tagged
 
 
@@ -575,3 +577,194 @@ class TestNFeIBSCBS(TransactionCase):
         # IBS Municipal should be zero
         self.assertEqual(result.gIBSCBS.gIBSMun.vIBSMun, "0.00")
         self.assertEqual(result.gIBSCBS.gIBSMun.pIBSMun, "0.0000")
+
+
+@tagged("post_install", "-at_install")
+class TestNFeVItemVNFTot(TransactionCase):
+    """Test vItem and vNFTot export in NFe documents (NT 2025.002)"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+        cls.company = cls.env.ref("base.main_company")
+        cls.icms_cst_00 = cls.env.ref("l10n_br_fiscal.cst_icms_00")
+
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "is_company": True,
+                "cnpj_cpf": "65910976000147",
+            }
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product",
+                "default_code": "TEST001",
+                "list_price": 100.0,
+            }
+        )
+
+        # Document with a real fiscal operation so that the document
+        # fiscal totals are computed (see l10n_br_fiscal.document.mixin)
+        cls.document = cls.env["l10n_br_fiscal.document"].create(
+            {
+                "company_id": cls.company.id,
+                "partner_id": cls.partner.id,
+                "fiscal_operation_type": "out",
+                "fiscal_operation_id": cls.env.ref("l10n_br_fiscal.fo_venda").id,
+                "document_type_id": cls.env.ref("l10n_br_fiscal.document_55").id,
+            }
+        )
+
+    def _build_det_binding(self, line):
+        """Build the real det binding for a document line"""
+        return line._build_binding(
+            spec_schema="nfe", spec_version="40", class_name="nfe.40.det"
+        )
+
+    def _build_total_binding(self):
+        """Build the real total binding for the document"""
+        return self.document._build_binding(
+            spec_schema="nfe", spec_version="40", class_name="nfe.40.total"
+        )
+
+    def test_export_det_binding_vitem_with_ibs_cbs(self):
+        """Test det binding exports vItem when the document has IBS/CBS"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
+
+        self.assertGreater(line.fiscal_amount_total, 0.0)
+        det = self._build_det_binding(line)
+        self.assertEqual(det.vItem, f"{line.fiscal_amount_total:.2f}")
+
+    def test_export_det_binding_vitem_mixed_lines(self):
+        """Test all lines export vItem when only one line has IBS/CBS"""
+        line_with = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line_without = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 50.0,
+            }
+        )
+        line_with.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
+
+        self.assertGreater(self.document.fiscal_amount_total, 0.0)
+        det_with = self._build_det_binding(line_with)
+        det_without = self._build_det_binding(line_without)
+        total = self._build_total_binding()
+
+        self.assertIsNotNone(det_with.vItem)
+        self.assertIsNotNone(det_without.vItem)
+        self.assertEqual(
+            Decimal(det_with.vItem) + Decimal(det_without.vItem),
+            Decimal(total.vNFTot),
+        )
+        self.assertEqual(
+            Decimal(total.vNFTot),
+            Decimal(total.ICMSTot.vNF),
+        )
+        self.assertEqual(
+            Decimal(total.vNFTot),
+            Decimal(f"{self.document.fiscal_amount_total:.2f}"),
+        )
+
+    def test_export_det_binding_vitem_with_discount(self):
+        """Test vItem uses the fiscal total instead of the gross price"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line.write({"discount_value": 10.0, "ibs_value": 0.1, "ibs_base": 90.0})
+
+        self.assertNotEqual(line.price_gross, line.fiscal_amount_total)
+        det = self._build_det_binding(line)
+        self.assertEqual(det.vItem, f"{line.fiscal_amount_total:.2f}")
+
+    def test_export_total_binding_with_vnftot(self):
+        """Test total binding exports vNFTot along with IBSCBSTot"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        line.write({"ibs_value": 0.1, "ibs_base": 100.0, "cbs_value": 0.9})
+
+        self.assertGreater(self.document.fiscal_amount_total, 0.0)
+        total = self._build_total_binding()
+        self.assertIsNotNone(total.IBSCBSTot)
+        self.assertEqual(total.vNFTot, f"{self.document.fiscal_amount_total:.2f}")
+
+    def test_export_bindings_absent_without_ibs_cbs(self):
+        """Test vItem and vNFTot are absent when there is no IBS/CBS"""
+        # Regression guard for the legacy behavior: it must stay green
+        # before and after the fix (it is not red-green evidence)
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+
+        det = self._build_det_binding(line)
+        total = self._build_total_binding()
+        self.assertIsNone(det.vItem)
+        self.assertIsNone(total.vNFTot)
+        self.assertIsNone(total.IBSCBSTot)
+
+    def test_export_field_vitem_and_vnftot_direct(self):
+        """Test direct _export_field calls for vItem and vNFTot"""
+        line = self.env["l10n_br_fiscal.document.line"].create(
+            {
+                "document_id": self.document.id,
+                "product_id": self.product.id,
+                "icms_cst_id": self.icms_cst_00.id,
+                "quantity": 1.0,
+                "price_unit": 100.0,
+            }
+        )
+        self.assertFalse(line._export_field("nfe40_vItem", None, None))
+        self.assertFalse(self.document._export_field("nfe40_vNFTot", None, None))
+
+        line.write({"ibs_value": 0.1, "ibs_base": 100.0})
+        self.assertEqual(
+            line._export_field("nfe40_vItem", None, None),
+            f"{line.fiscal_amount_total:.2f}",
+        )
+        self.assertEqual(
+            self.document._export_field("nfe40_vNFTot", None, None),
+            f"{self.document.fiscal_amount_total:.2f}",
+        )


### PR DESCRIPTION
## Resumo

Exporta as tags `vItem` (grupo VB, nível `det`) e `vNFTot` (grupo W03, em `<total>`) no XML da NF-e, conforme a NT 2025.002 (Reforma Tributária — IBS/CBS).

## Como reproduzir / Causa raiz

Uma NF-e emitida com o grupo `IBSCBS` é **autorizada** normalmente (as tags são opcionais no XSD), mas é reprovada na **malha fiscal** da SEFAZ (regras VB01/W60: `vItem` deve existir em todo `det` quando há `gIBSCBS`, e `vNFTot` é validado contra a soma dos `vItem`).

- Antes: `det` sem `<vItem>` e `IBSCBSTot` sem `<vNFTot>` irmão — o módulo nunca preenche esses campos (existiam só no spec).
- Depois: `<vItem>` em todos os `det` e `<vNFTot>` no `<total>`, presentes se-e-somente-se o documento exporta o grupo IBS/CBS (mesma guarda do `IBSCBSTot`); notas sem IBS/CBS geram XML idêntico ao atual.

## Solução

- `document.py`: helper `_nfe_export_ibscbs_totals()` (guarda única) + branch `nfe40_vNFTot` no `_export_field`, retornando `fiscal_amount_total`. O valor respeita o `tax_include` de cada grupo de imposto (`l10n_br_fiscal.tax.group`): como IBS/CBS/IS estão hoje marcados como incluídos no preço, não compõem o total e `vNFTot` = `vNF`; alterá-los para "não incluído" (por fora) passa a compô-lo automaticamente, sem mudança de código.
- `document_line.py`: branch `nfe40_vItem` no `_export_field` com guarda documental — inclusive em nota mista (linha sem IBS/CBS), preservando o invariante `Σ vItem == vNFTot == vNF`.
- Sem novos campos/computes: os campos do spec seguem stored/writable (round-trip de importação preservado); valor calculado só no export, no mesmo padrão dos overrides IBSCBS existentes.

**Testes**: classe `TestNFeVItemVNFTot` com asserts nos bindings reais (`nfe.40.det` / `nfe.40.total`), cenário misto com invariante em `Decimal`, cenário com desconto (`fiscal_amount_total != price_gross`) e guarda de ausência. Red-green comprovado (sem o fix: `None != '100.00'`). Suíte `l10n_br_nfe`: 84/84 verde em base limpa. **Patch coverage: 100%**.

Validado com emissão em homologação (nota autorizada, cStat 100) com as duas tags presentes e o invariante `Σ vItem == vNFTot == vNF` fechando.
